### PR TITLE
Run all v0.1.1+ migrations at startup

### DIFF
--- a/packages/app/graphql-server.ts
+++ b/packages/app/graphql-server.ts
@@ -478,6 +478,42 @@ async function runMigrations() {
   }
   // Add source_url column to recipes
   await sql`ALTER TABLE recipes ADD COLUMN IF NOT EXISTS source_url TEXT`;
+
+  // v0.1.1: Add notes to cookware (e.g. device guides, composting rules)
+  await sql`ALTER TABLE cookware ADD COLUMN IF NOT EXISTS notes TEXT`;
+
+  // v0.2.0: UUID join table replacing required_cookware TEXT[]
+  await sql`
+    CREATE TABLE IF NOT EXISTS recipe_cookware (
+      recipe_id   UUID NOT NULL REFERENCES recipes(id)  ON DELETE CASCADE,
+      cookware_id UUID NOT NULL REFERENCES cookware(id) ON DELETE CASCADE,
+      PRIMARY KEY (recipe_id, cookware_id)
+    )
+  `;
+  await sql`CREATE INDEX IF NOT EXISTS idx_recipe_cookware_recipe   ON recipe_cookware(recipe_id)`;
+  await sql`CREATE INDEX IF NOT EXISTS idx_recipe_cookware_cookware ON recipe_cookware(cookware_id)`;
+
+  // v0.3.0: Step-by-step photos for recipes
+  await sql`ALTER TABLE recipes ADD COLUMN IF NOT EXISTS step_photos TEXT[] DEFAULT '{}'`;
+
+  // v0.4.0: Two-dimension quantity on ingredients + recipe_ingredients.
+  // Lets users express "3 jars × 12 fl_oz each" in the pantry and "2 16oz
+  // pepper steaks" in a recipe. When item_size is set, the row's effective
+  // total is quantity × item_size measured in item_size_unit. When null,
+  // the row behaves exactly as before.
+  await sql`ALTER TABLE ingredients        ADD COLUMN IF NOT EXISTS item_size      DECIMAL`;
+  await sql`ALTER TABLE ingredients        ADD COLUMN IF NOT EXISTS item_size_unit VARCHAR(50)`;
+  await sql`ALTER TABLE recipe_ingredients ADD COLUMN IF NOT EXISTS item_size      DECIMAL`;
+  await sql`ALTER TABLE recipe_ingredients ADD COLUMN IF NOT EXISTS item_size_unit VARCHAR(50)`;
+
+  // v0.5.0: Opt-in barcode + product metadata on pantry ingredients.
+  await sql`ALTER TABLE ingredients ADD COLUMN IF NOT EXISTS barcode       VARCHAR(64)`;
+  await sql`ALTER TABLE ingredients ADD COLUMN IF NOT EXISTS product_meta  JSONB`;
+  await sql`CREATE INDEX IF NOT EXISTS idx_ingredients_barcode ON ingredients(barcode) WHERE barcode IS NOT NULL`;
+
+  // v0.5.1: Pantry-row aliases — alternative names that participate in
+  // recipe-ingredient matching.
+  await sql`ALTER TABLE ingredients ADD COLUMN IF NOT EXISTS aliases TEXT[]`;
 }
 
 // Keep the server alive on unexpected errors


### PR DESCRIPTION
## Summary

`runMigrations()` in `packages/app/graphql-server.ts` only covers the kitchens, slug, and source_url migrations. Everything from v0.1.1 onward (cookware.notes, recipe_cookware, step_photos, item_size{,_unit}, barcode, product_meta, aliases) lives exclusively in `packages/app/schema.sql`, which is only applied for fresh Docker installs via `docker-entrypoint-initdb.d`.

The practical consequence: any Postgres seeded from `docker-init.sql` (which the main README points at) never gets the v0.1.1+ columns. Mutations that touch `item_size` or friends fail with:

```
column "item_size" of relation "ingredients" does not exist
```

Because `graphql-server.ts` wraps Postgres errors into a `200 OK` + `errors[]` response, the UI symptom is just *"saves don't work"* — no visible error, no server crash.

This PR moves the remaining `IF NOT EXISTS` migrations from `schema.sql` into `runMigrations()` so the app self-heals on startup. Safe on fresh installs (every statement is already idempotent and becomes a no-op when `schema.sql` already applied it).

## Test plan
- [x] Run the app against a Postgres seeded with an old `docker-init.sql` — mutations touching `item_size` now succeed.
- [x] Run against a Postgres seeded with current `schema.sql` — migrations are no-ops (all `IF NOT EXISTS`).
- [ ] Consider eventually consolidating `docker-init.sql` and `schema.sql` into one source of truth so the two can't drift again.

---

Found while deploying the forked app into a reverse-proxy environment. Happy to split the schema consolidation into a follow-up.