### PR TITLE
SW: skip non-GET requests so the Cache API never sees them

### DIFF
--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -274,6 +274,14 @@ self.addEventListener('fetch', (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
+  // The Cache API only supports GET requests — any cache.put of a POST/PUT/
+  // DELETE request throws "Request method 'X' is unsupported". Today the
+  // only same-origin non-GET is not caught by any of the handlers below, but
+  // any future same-origin mutation endpoint would hit the generic
+  // stale-while-revalidate handler at the bottom and throw. Let non-GETs
+  // pass through to the network unconditionally.
+  if (request.method !== 'GET') return;
+
   // Federated recipe sources (Cooklang + recipe-api.com): dedicated TTL cache.
   if (isCachedRecipeSource(url)) {
     event.respondWith(cooklangHandler(request));


### PR DESCRIPTION
## Summary

The generic same-origin stale-while-revalidate handler at the bottom of the fetch listener unconditionally calls `cache.put()`. The Cache API only accepts GET — POST/PUT/DELETE throw:

\`\`\`
TypeError: Failed to execute 'put' on 'Cache': Request method 'POST' is unsupported.
\`\`\`

Today it's latent: GraphQL lives at a different origin (port 4001/4443) so the existing \`url.origin !== self.location.origin\` guard skips it. But any same-origin mutation endpoint added later would trip the handler and surface an uncaught promise rejection in every user's console.

One-liner: reject non-GETs at the top of the fetch listener, before any handler dispatch.

## Test plan
- [x] Existing GET flows unaffected (all handlers run the same paths).
- [x] Same-origin POST now passes straight to `fetch()` with no SW involvement.
- [x] Verified in devtools that no \`cache.put\` warnings appear for POST \`/graphql\` when wired to same-origin.