### PR TITLE
Dockerfile: support amd64 + arm64, install sharp linux binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Stage 1: Build
 FROM node:22-trixie-slim AS build
 
+# Target architecture (amd64|arm64) — populated automatically by buildx.
+ARG TARGETARCH
+
 RUN apt-get update && apt-get install -y libssl3t64 && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -14,14 +17,6 @@ COPY packages/web/package.json packages/web/
 COPY packages/mcp/package.json packages/mcp/
 RUN npm ci
 
-# Rex uses platform-specific native binaries — npm ci only installs for the
-# lockfile's platform. Force-install the Linux binary for Docker builds.
-RUN cd node_modules/@limlabs && npm pack @limlabs/rex-linux-arm64@0.20.0 && \
-    tar -xzf limlabs-rex-linux-arm64-0.20.0.tgz && \
-    mv package rex-linux-arm64 && \
-    rm limlabs-rex-linux-arm64-0.20.0.tgz && \
-    chmod +x rex-linux-arm64/bin/rex
-
 # Copy source
 COPY packages/app packages/app
 COPY packages/shared packages/shared
@@ -30,6 +25,15 @@ COPY packages/shared packages/shared
 RUN cd packages/app && mkdir -p node_modules && \
     ln -sf ../../../node_modules/react node_modules/react && \
     ln -sf ../../../node_modules/react-dom node_modules/react-dom
+
+# Rex + sharp ship platform-specific native binaries as optional deps.
+# npm ci sometimes skips the linux variant during cross-platform buildx
+# (e.g. building linux/amd64 on an arm64 Mac under qemu) because it
+# inspects the host lockfile / environment rather than the target. Force
+# the correct linux binary for the buildx target arch before building.
+RUN REX_PKG="@limlabs/rex-linux-$(case "$TARGETARCH" in amd64) echo x64 ;; arm64) echo arm64 ;; *) echo "$TARGETARCH" ;; esac)" && \
+    npm install "$REX_PKG" && \
+    npm install --os=linux --cpu="$(case "$TARGETARCH" in amd64) echo x64 ;; arm64) echo arm64 ;; *) echo "$TARGETARCH" ;; esac)" sharp
 
 # Build Rex for production
 RUN npx @limlabs/rex build --root packages/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 # Stage 1: Build
 FROM node:22-trixie-slim AS build
 
-# Target architecture (amd64|arm64) — populated automatically by buildx.
-ARG TARGETARCH
+# Target architecture (amd64|arm64). Populated automatically by BuildKit
+# for `docker buildx build`. Plain `docker build` without BuildKit leaves
+# it empty, so default to amd64 — matches the historical behavior where
+# the lockfile's npm binaries were x64.
+ARG TARGETARCH=amd64
 
 RUN apt-get update && apt-get install -y libssl3t64 && rm -rf /var/lib/apt/lists/*
 
@@ -31,9 +34,14 @@ RUN cd packages/app && mkdir -p node_modules && \
 # (e.g. building linux/amd64 on an arm64 Mac under qemu) because it
 # inspects the host lockfile / environment rather than the target. Force
 # the correct linux binary for the buildx target arch before building.
-RUN REX_PKG="@limlabs/rex-linux-$(case "$TARGETARCH" in amd64) echo x64 ;; arm64) echo arm64 ;; *) echo "$TARGETARCH" ;; esac)" && \
-    npm install "$REX_PKG" && \
-    npm install --os=linux --cpu="$(case "$TARGETARCH" in amd64) echo x64 ;; arm64) echo arm64 ;; *) echo "$TARGETARCH" ;; esac)" sharp
+#
+# The Rex native binary is pinned to the version npm ci already resolved
+# for @limlabs/rex in the root lockfile — a JS-loader / native-binary
+# version mismatch fails at runtime rather than build time.
+RUN ARCH="$(case "$TARGETARCH" in amd64) echo x64 ;; arm64) echo arm64 ;; *) echo "$TARGETARCH" ;; esac)" && \
+    REX_VERSION="$(node -p "require('./node_modules/@limlabs/rex/package.json').version")" && \
+    npm install "@limlabs/rex-linux-${ARCH}@${REX_VERSION}" && \
+    npm install --os=linux --cpu="${ARCH}" sharp
 
 # Build Rex for production
 RUN npx @limlabs/rex build --root packages/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
 # Stage 1: Build
 FROM node:22-trixie-slim AS build
 
-# Target architecture (amd64|arm64). Populated automatically by BuildKit
-# for `docker buildx build`. Plain `docker build` without BuildKit leaves
-# it empty, so default to amd64 — matches the historical behavior where
-# the lockfile's npm binaries were x64.
-ARG TARGETARCH=amd64
-
 RUN apt-get update && apt-get install -y libssl3t64 && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -33,12 +27,17 @@ RUN cd packages/app && mkdir -p node_modules && \
 # npm ci sometimes skips the linux variant during cross-platform buildx
 # (e.g. building linux/amd64 on an arm64 Mac under qemu) because it
 # inspects the host lockfile / environment rather than the target. Force
-# the correct linux binary for the buildx target arch before building.
+# the correct linux binary for the stage's actual runtime arch before
+# building.
+#
+# Using `uname -m` here rather than BuildKit's $TARGETARCH: the stage's
+# actual runtime arch is always correct under emulated buildx and it's
+# also available in plain (non-BuildKit) `docker build` — no ARG dance.
 #
 # The Rex native binary is pinned to the version npm ci already resolved
 # for @limlabs/rex in the root lockfile — a JS-loader / native-binary
 # version mismatch fails at runtime rather than build time.
-RUN ARCH="$(case "$TARGETARCH" in amd64) echo x64 ;; arm64) echo arm64 ;; *) echo "$TARGETARCH" ;; esac)" && \
+RUN ARCH="$(case "$(uname -m)" in x86_64) echo x64 ;; aarch64) echo arm64 ;; *) echo "unsupported-$(uname -m)" ;; esac)" && \
     REX_VERSION="$(node -p "require('./node_modules/@limlabs/rex/package.json').version")" && \
     npm install "@limlabs/rex-linux-${ARCH}@${REX_VERSION}" && \
     npm install --os=linux --cpu="${ARCH}" sharp


### PR DESCRIPTION
## Summary

Two related problems with the existing Dockerfile:

1. It hardcodes \`@limlabs/rex-linux-arm64\` — so any **amd64** target (most CI runners, most cloud deploys) ends up with a Rex binary for the wrong architecture and rex fails at build or runtime.
2. \`sharp\` is an optional peer binary in the same boat as Rex. Cross-platform buildx + qemu can silently skip the linux variant, so \`graphql-server.ts\` crashes on startup with:

\`\`\`
Error: Could not load the "sharp" module using the linux-x64 runtime
\`\`\`

Because the GraphQL server is backgrounded from \`docker-entrypoint.sh\` (\`npx tsx graphql-server.ts &\`), its crash doesn't kill the container — Rex keeps running, the page loads, and every mutation silently 502s.

### Fix

- Read the buildx-provided \`$TARGETARCH\` at build time.
- Install the matching \`@limlabs/rex-linux-<arch>\` (x64 for amd64, arm64 for arm64) in one line — no more hardcoded version pin/npm pack tarball extraction.
- Install \`sharp\` with \`npm install --os=linux --cpu=<arch>\` so the linux native prebuild is always grabbed.

### Test plan

- [x] \`docker buildx build --platform linux/amd64\` on an arm64 Mac — image runs cleanly, graphql-server starts, mutations succeed.
- [ ] \`docker buildx build --platform linux/arm64\` — should get \`rex-linux-arm64\` and \`sharp\` arm64 prebuild (haven't tested but the case branch mirrors the old hardcoded path).
- [ ] Native \`docker build\` on a linux/amd64 host — \`TARGETARCH\` defaults to the host arch, same codepath.

Found while deploying the app into a reverse-proxy / podman setup on a linux/amd64 host built from an arm64 Mac. Happy to split the rex-version unpin into a separate PR if you want to land sharp first.