### PR TITLE
Use same-origin API URLs when behind a reverse proxy

### DIFF
--- a/packages/app/components/RecipeForm.tsx
+++ b/packages/app/components/RecipeForm.tsx
@@ -7,6 +7,7 @@ const COUNT_UNITS: readonly string[] = UNIT_GROUPS.find((g) => g.label === 'Coun
 import IngredientEditor, { resolveIngredients, type IngredientRow } from '@pantry-host/shared/components/IngredientEditor';
 import { extractCooklang, hasCooklangSyntax, updateCooklangIngredient, parseCooklangMetadata } from '@pantry-host/shared/cooklang-parser';
 import { gql } from '@/lib/gql';
+import { apiUrl } from '@/lib/apiUrl';
 import { enqueue } from '@/lib/offlineQueue';
 
 interface RecipeIngredient {
@@ -224,9 +225,7 @@ export default function RecipeForm({ initial, existingRecipes = [], cookwareItem
     setImporting(true);
     setImportError(null);
     try {
-      const proto = window.location.protocol === 'https:' ? 'https' : 'http';
-      const port = proto === 'https' ? 4443 : 4001;
-      const res = await fetch(`${proto}://${window.location.hostname}:${port}/fetch-recipe`, {
+      const res = await fetch(apiUrl('/fetch-recipe'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ url: importUrl.trim() }),

--- a/packages/app/components/UrlImportCommon.tsx
+++ b/packages/app/components/UrlImportCommon.tsx
@@ -11,6 +11,7 @@ import Head from 'next/head';
 import UrlRecipeDetail from '@pantry-host/shared/components/UrlRecipeDetail';
 import type { ParsedRecipe } from '@pantry-host/shared/bluesky';
 import { gql } from '@/lib/gql';
+import { apiUrl } from '@/lib/apiUrl';
 
 const CREATE_RECIPE = `
   mutation CreateRecipe(
@@ -53,7 +54,7 @@ export default function UrlImportCommon({ scheme }: { scheme: 'http' | 'https' }
   }, [scheme]);
 
   const fetcher = useCallback(async (url: string) => {
-    const res = await fetch(`http://${window.location.hostname}:4001/fetch-recipe`, {
+    const res = await fetch(apiUrl('/fetch-recipe'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ url }),

--- a/packages/app/components/pages/RecipeImportPage.tsx
+++ b/packages/app/components/pages/RecipeImportPage.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/router';
 import { gql } from '@/lib/gql';
 import { isApiOnline, API_STATUS_EVENT } from '@/lib/apiStatus';
+import { apiUrl } from '@/lib/apiUrl';
 import {
   searchFederationRecipes,
   getFederationRecipe,
@@ -753,7 +754,7 @@ export default function RecipeImportPage({ kitchen }: Props) {
               // AT URIs fetched client-side (bsky.social has open CORS)
               data = await fetchBlueskyRecipe(item.url) as unknown as ParsedRecipe;
             } else {
-              const res = await fetch(`http://${window.location.hostname}:4001/fetch-recipe`, {
+              const res = await fetch(apiUrl('/fetch-recipe'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ url: item.url }),

--- a/packages/app/lib/apiStatus.ts
+++ b/packages/app/lib/apiStatus.ts
@@ -4,6 +4,8 @@
  * the Mac Mini at home. This module detects that.
  */
 
+import { apiUrl } from './apiUrl';
+
 export const API_STATUS_EVENT = 'api-status-change';
 
 let _online = true;
@@ -32,16 +34,9 @@ export function setApiOnline(online: boolean): void {
   }
 }
 
-function getGqlUrl(): string {
-  if (typeof window === 'undefined') return 'http://localhost:4001/graphql';
-  const proto = window.location.protocol === 'https:' ? 'https' : 'http';
-  const gqlPort = proto === 'https' ? 4443 : 4001;
-  return `${proto}://${window.location.hostname}:${gqlPort}/graphql`;
-}
-
 async function checkApi(): Promise<void> {
   try {
-    const res = await fetch(getGqlUrl(), {
+    const res = await fetch(apiUrl('/graphql'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query: '{ __typename }' }),

--- a/packages/app/lib/apiUrl.ts
+++ b/packages/app/lib/apiUrl.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolve a URL for the backend API server (graphql-server.ts, port 4001).
+ *
+ * Deployment modes this supports:
+ *   - Dev (`rex dev`):       frontend on :3000,  API on :4001
+ *   - Dev (local-ssl-proxy): frontend on :3443,  API on :4443
+ *   - Reverse proxy deploy:  frontend + API on :80/:443, API mounted at path
+ *
+ * The frontend detects the mode from window.location.port — an empty port
+ * means standard 80/443, which is the reverse-proxy case, so the API is
+ * assumed to be reachable at the same origin (proxy forwards /graphql and
+ * /fetch-recipe to the backend). Otherwise we fall back to the dedicated
+ * backend port (4001 http, 4443 https) matching the dev scripts.
+ *
+ * Server-side rendering always hits localhost:4001.
+ */
+export function apiUrl(path: string): string {
+  if (typeof window === 'undefined') return `http://localhost:4001${path}`;
+  if (!window.location.port) return path;
+  const proto = window.location.protocol === 'https:' ? 'https' : 'http';
+  const port = proto === 'https' ? 4443 : 4001;
+  return `${proto}://${window.location.hostname}:${port}${path}`;
+}

--- a/packages/app/lib/gql.ts
+++ b/packages/app/lib/gql.ts
@@ -2,13 +2,7 @@
  * Lightweight client-side GraphQL fetch helper.
  */
 import { setApiOnline } from './apiStatus';
-
-function getGraphqlUrl(): string {
-  if (typeof window === 'undefined') return 'http://localhost:4001/graphql';
-  const proto = window.location.protocol === 'https:' ? 'https' : 'http';
-  const gqlPort = proto === 'https' ? 4443 : 4001;
-  return `${proto}://${window.location.hostname}:${gqlPort}/graphql`;
-}
+import { apiUrl } from './apiUrl';
 
 /** Timeout in ms for GraphQL fetches. The server is on localhost/LAN so it
  * responds in <100ms when reachable. 4s is generous for cold starts but fast
@@ -26,7 +20,7 @@ export async function gql<T = unknown>(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), isMutation ? GQL_TIMEOUT_LONG : GQL_TIMEOUT);
   try {
-    res = await fetch(getGraphqlUrl(), {
+    res = await fetch(apiUrl('/graphql'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query, variables }),


### PR DESCRIPTION
## Summary

Five client sites (\`lib/gql.ts\`, \`lib/apiStatus.ts\`, \`RecipeForm.tsx\`, \`UrlImportCommon.tsx\`, \`RecipeImportPage.tsx\`) each independently build the API URL as:

\`\`\`ts
\`\${proto}://\${window.location.hostname}:\${proto === 'https' ? 4443 : 4001}\`
\`\`\`

That works when the deployer can expose both the frontend port (\`3000\`/\`3443\`) and the API port (\`4001\`/\`4443\`) to every client — which is exactly the documented local-ssl-proxy dev setup. But for any production-style reverse-proxy deploy (nginx/Caddy/Traefik/cloudflared terminating TLS on \`80\`/\`443\` and serving the app on a single origin), the client ends up asking for \`https://host:4443/graphql\` and hits \`ERR_CONNECTION_REFUSED\`.

### Change

Consolidate the URL construction into a new \`lib/apiUrl.ts\`:

| Context                               | Returned URL                                          |
|---------------------------------------|-------------------------------------------------------|
| SSR (\`typeof window === 'undefined'\`) | \`http://localhost:4001<path>\`                         |
| Browser with explicit port (dev)      | \`<proto>://<hostname>:<4001\|4443><path>\`             |
| Browser with no port (80/443)         | \`<path>\` (same-origin — proxy forwards to backend)    |

Use it in all five sites.

### Why `window.location.port` as the signal

Standard ports (80, 443) come through as an empty string in \`window.location.port\`. Every existing dev flow uses non-standard ports (\`3000\`, \`3443\`, \`4001\`, \`4443\`), so \`port === ''\` is a reliable proxy for "running behind nginx/Caddy/etc.". No env var, no build-time config.

### Test plan

- [x] Reverse proxy on \`:443\` forwarding \`/graphql\` and \`/fetch-recipe\` to \`localhost:4001\` — app works end-to-end.
- [ ] \`rex dev\` on \`:3000\` (frontend) + \`:4001\` (graphql-server) — client should still point at \`:4001\`.
- [ ] local-ssl-proxy \`:3443\`→\`:3000\` + \`:4443\`→\`:4001\` — client should still point at \`:4443\`.

Dev flow unchanged; reverse-proxy deploys unblocked without having to fork-patch the client.

### Related

Part of a small series of PRs from deploying the app into a podman + nginx environment:
- #17 (run all migrations at startup)
- #18 (SW skip non-GET)
- #19 (Dockerfile multi-arch + sharp)