### PR TITLE
add integration test suite for backend server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ CLAUDE.local.md
 .wrangler
 witness/output/*
 !witness/output/.gitkeep
+tests/integration/__harness__.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,9 @@
         "react-dom": "^19.2.4"
       },
       "devDependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@types/pg": "^8.11.10",
+        "pg": "^8.13.1"
       },
       "optionalDependencies": {
         "@img/sharp-darwin-x64": "^0.34.5",
@@ -1932,6 +1934,18 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/qrcode": {
@@ -4140,6 +4154,103 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "dev": true,
@@ -4376,6 +4487,49 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -5953,6 +6107,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:web": "npm run dev -w packages/web",
     "dev:mcp": "npm run dev -w packages/mcp",
     "test:smoke": "npx tsx witness/run-smoke.ts",
+    "test:integration": "node tests/integration/run.ts",
     "screencasts": "npx tsx witness/screencasts/generate-all.ts"
   },
   "dependencies": {
@@ -23,7 +24,9 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@types/pg": "^8.11.10",
+    "pg": "^8.13.1"
   },
   "optionalDependencies": {
     "@img/sharp-darwin-x64": "^0.34.5",

--- a/tests/integration/cookware.test.ts
+++ b/tests/integration/cookware.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { gql } from './helpers/gql.ts';
+import { resetDb } from './helpers/reset.ts';
+
+const ADD = `
+  mutation Add($name: String!, $brand: String) {
+    addCookware(name: $name, brand: $brand) { id name brand }
+  }
+`;
+const LIST = `query { cookware { id name brand } }`;
+const UPDATE = `
+  mutation U($id: String!, $brand: String) {
+    updateCookware(id: $id, brand: $brand) { id brand }
+  }
+`;
+const DELETE = `mutation D($id: String!) { deleteCookware(id: $id) }`;
+
+describe('cookware CRUD', () => {
+  beforeEach(() => resetDb());
+
+  it('creates, updates, lists, and deletes a cookware item', async () => {
+    const { addCookware } = await gql<{
+      addCookware: { id: string; name: string; brand: string | null };
+    }>(ADD, { name: 'Cast Iron Skillet' });
+    assert.equal(addCookware.name, 'Cast Iron Skillet');
+    assert.equal(addCookware.brand, null);
+
+    const { updateCookware } = await gql<{
+      updateCookware: { brand: string };
+    }>(UPDATE, { id: addCookware.id, brand: 'Lodge' });
+    assert.equal(updateCookware.brand, 'Lodge');
+
+    const { cookware: list1 } = await gql<{
+      cookware: { name: string; brand: string | null }[];
+    }>(LIST);
+    assert.equal(
+      list1.find((c) => c.name === 'Cast Iron Skillet')?.brand,
+      'Lodge',
+    );
+
+    const { deleteCookware } = await gql<{ deleteCookware: boolean }>(DELETE, {
+      id: addCookware.id,
+    });
+    assert.equal(deleteCookware, true);
+
+    const { cookware: list2 } = await gql<{ cookware: { name: string }[] }>(
+      LIST,
+    );
+    assert.ok(!list2.some((c) => c.name === 'Cast Iron Skillet'));
+  });
+});

--- a/tests/integration/fetch-recipe.test.ts
+++ b/tests/integration/fetch-recipe.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { harness } from './helpers/harness.ts';
+
+describe('POST /fetch-recipe', () => {
+  // URL passed in the request body is fetched and parsed; the mock server's
+  // /recipe.html serves LD-JSON for the happy path.
+  it('parses LD-JSON Recipe data from a mock page', async () => {
+    const { url, mockUrl } = harness();
+    const r = await fetch(`${url}/fetch-recipe`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url: `${mockUrl}/recipe.html` }),
+    });
+    assert.ok(r.ok);
+
+    const data = (await r.json()) as {
+      title: string;
+      ingredients: { ingredientName: string }[];
+      instructions: string;
+      servings?: number;
+      prepTime?: number;
+      cookTime?: number;
+    };
+    assert.equal(data.title, 'Mock Tomato Soup');
+    assert.equal(data.ingredients.length, 3);
+    assert.ok(
+      data.ingredients.some((i) =>
+        i.ingredientName.toLowerCase().includes('tomato'),
+      ),
+    );
+    assert.equal(data.servings, 4);
+    assert.equal(data.prepTime, 5);
+    assert.equal(data.cookTime, 25);
+    assert.match(data.instructions, /Saute the onion/);
+  });
+
+  it('returns 502 when the target URL is unreachable', async () => {
+    const { url } = harness();
+    const r = await fetch(`${url}/fetch-recipe`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url: 'http://127.0.0.1:1/nope' }),
+    });
+    assert.equal(r.status, 502);
+  });
+
+  it('returns 400 when the request omits the url field', async () => {
+    const { url } = harness();
+    const r = await fetch(`${url}/fetch-recipe`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(r.status, 400);
+  });
+});

--- a/tests/integration/generate-recipes.test.ts
+++ b/tests/integration/generate-recipes.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { gql } from './helpers/gql.ts';
+import { resetDb } from './helpers/reset.ts';
+
+// Anthropic SDK is redirected at the local mock via ANTHROPIC_BASE_URL.
+
+const ADD_ING = `
+  mutation AI($name: String!) {
+    addIngredient(name: $name) { id name }
+  }
+`;
+const ADD_COOK = `
+  mutation AC($name: String!) {
+    addCookware(name: $name) { id name }
+  }
+`;
+const GENERATE = `
+  mutation Generate {
+    generateRecipes {
+      id slug title tags source
+      ingredients { ingredientName quantity unit }
+    }
+  }
+`;
+const LIST = `query { recipes { title source } }`;
+
+describe('generateRecipes (Anthropic mocked via ANTHROPIC_BASE_URL)', () => {
+  beforeEach(() => resetDb());
+
+  it('persists the three mock recipes and tags them as ai-generated', async () => {
+    await gql(ADD_ING, { name: 'Salt' });
+    await gql(ADD_ING, { name: 'Pepper' });
+    await gql(ADD_COOK, { name: 'Bowl' });
+
+    const { generateRecipes } = await gql<{
+      generateRecipes: {
+        id: string;
+        title: string;
+        source: string;
+        ingredients: { ingredientName: string }[];
+      }[];
+    }>(GENERATE);
+
+    assert.equal(generateRecipes.length, 3);
+    assert.deepEqual(generateRecipes.map((r) => r.title).sort(), [
+      'Mock Mixed Bowl',
+      'Mock Pepper Bowl',
+      'Mock Salt Bowl',
+    ]);
+    assert.ok(generateRecipes.every((r) => r.source === 'ai-generated'));
+
+    const { recipes } = await gql<{
+      recipes: { title: string; source: string }[];
+    }>(LIST);
+    assert.deepEqual(recipes.map((r) => r.title).sort(), [
+      'Mock Mixed Bowl',
+      'Mock Pepper Bowl',
+      'Mock Salt Bowl',
+    ]);
+  });
+});

--- a/tests/integration/helpers/gql.ts
+++ b/tests/integration/helpers/gql.ts
@@ -1,0 +1,31 @@
+import { harness } from './harness.ts';
+
+interface GqlResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
+}
+
+export async function gql<T = Record<string, unknown>>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const { url } = harness();
+  const r = await fetch(`${url}/graphql`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ query, variables: variables ?? {} }),
+  });
+  if (!r.ok) {
+    throw new Error(`HTTP ${r.status} from /graphql: ${await r.text()}`);
+  }
+  const body = (await r.json()) as GqlResponse<T>;
+  if (body.errors?.length) {
+    throw new Error(
+      `GraphQL errors: ${body.errors.map((e) => e.message).join('; ')}`,
+    );
+  }
+  if (body.data === undefined) {
+    throw new Error('GraphQL response missing data field');
+  }
+  return body.data;
+}

--- a/tests/integration/helpers/harness.ts
+++ b/tests/integration/helpers/harness.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface HarnessHandle {
+  url: string;
+  dbUrl: string;
+  mockUrl: string;
+  serverPid: number;
+  containerId: string;
+  containerName: string;
+  dbName: string;
+  dbUser: string;
+}
+
+const FILE = join(import.meta.dirname, '..', '__harness__.json');
+let cached: HarnessHandle | undefined;
+
+export function harness(): HarnessHandle {
+  if (!cached) {
+    cached = JSON.parse(readFileSync(FILE, 'utf8')) as HarnessHandle;
+  }
+  return cached;
+}

--- a/tests/integration/helpers/mock-server.ts
+++ b/tests/integration/helpers/mock-server.ts
@@ -1,0 +1,114 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+const MOCK_RECIPE_HTML = `<!doctype html>
+<html>
+<head>
+  <title>Mock Tomato Soup</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Recipe",
+    "name": "Mock Tomato Soup",
+    "recipeIngredient": ["2 cups tomatoes", "1 onion", "3 cups stock"],
+    "recipeInstructions": [
+      { "@type": "HowToStep", "text": "Saute the onion" },
+      { "@type": "HowToStep", "text": "Add tomatoes and stock" },
+      { "@type": "HowToStep", "text": "Simmer 20 minutes" }
+    ],
+    "recipeYield": "4",
+    "prepTime": "PT5M",
+    "cookTime": "PT25M"
+  }
+  </script>
+</head>
+<body><h1>Mock Tomato Soup</h1></body>
+</html>`;
+
+const MOCK_GENERATED_RECIPES = [
+  {
+    title: 'Mock Salt Bowl',
+    description: 'A bowl of salt.',
+    instructions: '1. Pour salt into bowl.\n2. Serve.',
+    servings: 1,
+    prepTime: 1,
+    cookTime: 0,
+    tags: ['salty'],
+    requiredCookware: [],
+    ingredients: [{ ingredientName: 'Salt', quantity: 1, unit: 'tbsp' }],
+  },
+  {
+    title: 'Mock Pepper Bowl',
+    description: 'A bowl of pepper.',
+    instructions: '1. Pour pepper into bowl.\n2. Serve.',
+    servings: 1,
+    prepTime: 1,
+    cookTime: 0,
+    tags: ['spicy'],
+    requiredCookware: [],
+    ingredients: [{ ingredientName: 'Pepper', quantity: 1, unit: 'tbsp' }],
+  },
+  {
+    title: 'Mock Mixed Bowl',
+    description: 'A mix of both.',
+    instructions: '1. Combine salt and pepper.\n2. Serve.',
+    servings: 1,
+    prepTime: 1,
+    cookTime: 0,
+    tags: ['balanced'],
+    requiredCookware: [],
+    ingredients: [
+      { ingredientName: 'Salt', quantity: 1, unit: 'tsp' },
+      { ingredientName: 'Pepper', quantity: 1, unit: 'tsp' },
+    ],
+  },
+];
+
+export interface MockServer {
+  url: string;
+  stop(): Promise<void>;
+}
+
+export async function startMockServer(): Promise<MockServer> {
+  const server: Server = createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/recipe.html') {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(MOCK_RECIPE_HTML);
+      return;
+    }
+    if (req.method === 'POST' && req.url === '/v1/messages') {
+      const payload = {
+        id: 'msg_mock',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-sonnet-4-6-mock',
+        content: [
+          { type: 'text', text: JSON.stringify(MOCK_GENERATED_RECIPES) },
+        ],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 0, output_tokens: 0 },
+      };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(payload));
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('mock: not found');
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const port = (server.address() as AddressInfo).port;
+  const url = `http://127.0.0.1:${port}`;
+
+  return {
+    url,
+    stop: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}

--- a/tests/integration/helpers/reset.ts
+++ b/tests/integration/helpers/reset.ts
@@ -1,0 +1,24 @@
+import { Client } from 'pg';
+import { harness } from './harness.ts';
+
+// Keeps the seeded 'home' kitchen because data tables reference it.
+export async function resetDb(): Promise<void> {
+  const client = new Client({ connectionString: harness().dbUrl });
+  await client.connect();
+  try {
+    await client.query(`
+      TRUNCATE TABLE
+        menu_recipes,
+        recipe_cookware,
+        recipe_ingredients,
+        menus,
+        recipes,
+        cookware,
+        ingredients
+      RESTART IDENTITY CASCADE
+    `);
+    await client.query(`DELETE FROM kitchens WHERE slug != 'home'`);
+  } finally {
+    await client.end();
+  }
+}

--- a/tests/integration/ingredients.test.ts
+++ b/tests/integration/ingredients.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { gql } from './helpers/gql.ts';
+import { resetDb } from './helpers/reset.ts';
+
+const ADD = `
+  mutation Add($name: String!, $tags: [String!]) {
+    addIngredient(name: $name, tags: $tags) { id name tags }
+  }
+`;
+const LIST = `
+  query List($name: String, $tags: [String!]) {
+    ingredients(name: $name, tags: $tags) { id name tags }
+  }
+`;
+const UPDATE = `
+  mutation Update($id: String!, $name: String) {
+    updateIngredient(id: $id, name: $name) { id name }
+  }
+`;
+const DELETE = `mutation Del($id: String!) { deleteIngredient(id: $id) }`;
+const ADD_BULK = `
+  mutation AddBulk($inputs: [IngredientInput!]!) {
+    addIngredients(inputs: $inputs) { id name }
+  }
+`;
+
+describe('ingredients CRUD', () => {
+  beforeEach(() => resetDb());
+
+  it('adds an ingredient and lists it', async () => {
+    const { addIngredient } = await gql<{
+      addIngredient: { id: string; name: string; tags: string[] };
+    }>(ADD, { name: 'Eggs', tags: ['fridge'] });
+    assert.equal(addIngredient.name, 'Eggs');
+    assert.deepEqual(addIngredient.tags, ['fridge']);
+
+    const { ingredients } = await gql<{ ingredients: { name: string }[] }>(LIST);
+    assert.ok(ingredients.some((i) => i.name === 'Eggs'));
+  });
+
+  it('updates an ingredient name', async () => {
+    const { addIngredient } = await gql<{ addIngredient: { id: string } }>(
+      ADD,
+      { name: 'Tomato' },
+    );
+    const { updateIngredient } = await gql<{
+      updateIngredient: { name: string };
+    }>(UPDATE, { id: addIngredient.id, name: 'Heirloom Tomato' });
+    assert.equal(updateIngredient.name, 'Heirloom Tomato');
+  });
+
+  it('deletes an ingredient', async () => {
+    const { addIngredient } = await gql<{ addIngredient: { id: string } }>(
+      ADD,
+      { name: 'Bread' },
+    );
+    const { deleteIngredient } = await gql<{ deleteIngredient: boolean }>(
+      DELETE,
+      { id: addIngredient.id },
+    );
+    assert.equal(deleteIngredient, true);
+
+    const { ingredients } = await gql<{ ingredients: { name: string }[] }>(LIST);
+    assert.ok(!ingredients.some((i) => i.name === 'Bread'));
+  });
+
+  it('bulk inserts ingredients', async () => {
+    const inputs = ['Salt', 'Pepper', 'Olive Oil', 'Garlic', 'Onion'].map(
+      (name) => ({ name }),
+    );
+    const { addIngredients } = await gql<{
+      addIngredients: { id: string; name: string }[];
+    }>(ADD_BULK, { inputs });
+    assert.equal(addIngredients.length, 5);
+    assert.deepEqual(addIngredients.map((i) => i.name).sort(), [
+      'Garlic',
+      'Olive Oil',
+      'Onion',
+      'Pepper',
+      'Salt',
+    ]);
+  });
+
+  it('filters by name (ILIKE substring, case-insensitive)', async () => {
+    await gql(ADD, { name: 'Pickled Onions' });
+    await gql(ADD, { name: 'Red Onion' });
+    await gql(ADD, { name: 'Garlic' });
+    const { ingredients } = await gql<{ ingredients: { name: string }[] }>(
+      LIST,
+      { name: 'onion' },
+    );
+    assert.deepEqual(ingredients.map((i) => i.name).sort(), [
+      'Pickled Onions',
+      'Red Onion',
+    ]);
+  });
+
+  it('filters by tags (array containment)', async () => {
+    await gql(ADD, { name: 'Milk', tags: ['fridge', 'dairy'] });
+    await gql(ADD, { name: 'Butter', tags: ['fridge', 'dairy'] });
+    await gql(ADD, { name: 'Flour', tags: ['pantry'] });
+    const { ingredients } = await gql<{ ingredients: { name: string }[] }>(
+      LIST,
+      { tags: ['dairy'] },
+    );
+    assert.deepEqual(ingredients.map((i) => i.name).sort(), [
+      'Butter',
+      'Milk',
+    ]);
+  });
+});

--- a/tests/integration/kitchens.test.ts
+++ b/tests/integration/kitchens.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { gql } from './helpers/gql.ts';
+import { resetDb } from './helpers/reset.ts';
+
+const CREATE = `
+  mutation C($slug: String!, $name: String!) {
+    createKitchen(slug: $slug, name: $name) { id slug name }
+  }
+`;
+const LIST = `query { kitchens { slug name } }`;
+const UPDATE = `
+  mutation U($id: String!, $name: String!) {
+    updateKitchen(id: $id, name: $name) { id name }
+  }
+`;
+const DELETE = `mutation D($id: String!) { deleteKitchen(id: $id) }`;
+const ONE = `query One($slug: String!) { kitchen(slug: $slug) { slug name } }`;
+
+describe('kitchens CRUD', () => {
+  beforeEach(() => resetDb());
+
+  it('the seeded home kitchen always exists', async () => {
+    const { kitchen } = await gql<{
+      kitchen: { slug: string; name: string } | null;
+    }>(ONE, { slug: 'home' });
+    assert.equal(kitchen?.slug, 'home');
+    assert.equal(kitchen?.name, 'Home');
+  });
+
+  it('creates a new kitchen and lists it', async () => {
+    await gql(CREATE, { slug: 'beach-house', name: 'Beach House' });
+    const { kitchens } = await gql<{
+      kitchens: { slug: string; name: string }[];
+    }>(LIST);
+    assert.equal(
+      kitchens.find((k) => k.slug === 'beach-house')?.name,
+      'Beach House',
+    );
+  });
+
+  it('rejects the reserved "home" slug', async () => {
+    await assert.rejects(
+      gql(CREATE, { slug: 'home', name: 'Duplicate Home' }),
+      /reserved/i,
+    );
+  });
+
+  it('rejects invalid slug characters', async () => {
+    await assert.rejects(gql(CREATE, { slug: 'Bad Slug!', name: 'X' }));
+  });
+
+  it('rejects a duplicate slug', async () => {
+    await gql(CREATE, { slug: 'cabin', name: 'Cabin' });
+    await assert.rejects(gql(CREATE, { slug: 'cabin', name: 'Other Cabin' }));
+  });
+
+  it('updates and deletes a non-home kitchen', async () => {
+    const { createKitchen } = await gql<{ createKitchen: { id: string } }>(
+      CREATE,
+      { slug: 'studio', name: 'Studio' },
+    );
+    const { updateKitchen } = await gql<{ updateKitchen: { name: string } }>(
+      UPDATE,
+      { id: createKitchen.id, name: 'Studio Apartment' },
+    );
+    assert.equal(updateKitchen.name, 'Studio Apartment');
+
+    await gql(DELETE, { id: createKitchen.id });
+    const { kitchens } = await gql<{ kitchens: { slug: string }[] }>(LIST);
+    assert.ok(!kitchens.some((k) => k.slug === 'studio'));
+  });
+});

--- a/tests/integration/menus.test.ts
+++ b/tests/integration/menus.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { gql } from './helpers/gql.ts';
+import { resetDb } from './helpers/reset.ts';
+
+const CREATE_RECIPE = `
+  mutation CR($title: String!) {
+    createRecipe(title: $title, instructions: "x", ingredients: []) {
+      id title
+    }
+  }
+`;
+const CREATE_MENU = `
+  mutation CM($title: String!, $recipes: [MenuRecipeInput!]!) {
+    createMenu(title: $title, recipes: $recipes) {
+      id title slug active
+      recipes { course recipe { title } }
+    }
+  }
+`;
+const TOGGLE = `
+  mutation T($menuId: String!, $recipeId: String!, $course: String) {
+    toggleRecipeInMenu(menuId: $menuId, recipeId: $recipeId, course: $course) {
+      id
+      recipes { recipe { title } }
+    }
+  }
+`;
+const UPDATE = `
+  mutation U($id: String!, $title: String) {
+    updateMenu(id: $id, title: $title) { id title }
+  }
+`;
+const DELETE = `mutation D($id: String!) { deleteMenu(id: $id) }`;
+const LIST = `query { menus { id title } }`;
+
+describe('menus + recipe linking', () => {
+  beforeEach(() => resetDb());
+
+  it('creates a menu with two recipes, then toggles a third in', async () => {
+    const r1 = await gql<{ createRecipe: { id: string } }>(CREATE_RECIPE, {
+      title: 'Starter Soup',
+    });
+    const r2 = await gql<{ createRecipe: { id: string } }>(CREATE_RECIPE, {
+      title: 'Main Roast',
+    });
+    const r3 = await gql<{ createRecipe: { id: string } }>(CREATE_RECIPE, {
+      title: 'Dessert Tart',
+    });
+
+    const { createMenu } = await gql<{
+      createMenu: { id: string; recipes: { recipe: { title: string } }[] };
+    }>(CREATE_MENU, {
+      title: 'Sunday Dinner',
+      recipes: [
+        { recipeId: r1.createRecipe.id, course: 'starter' },
+        { recipeId: r2.createRecipe.id, course: 'main' },
+      ],
+    });
+    assert.deepEqual(createMenu.recipes.map((r) => r.recipe.title).sort(), [
+      'Main Roast',
+      'Starter Soup',
+    ]);
+
+    const { toggleRecipeInMenu } = await gql<{
+      toggleRecipeInMenu: { recipes: { recipe: { title: string } }[] };
+    }>(TOGGLE, {
+      menuId: createMenu.id,
+      recipeId: r3.createRecipe.id,
+      course: 'dessert',
+    });
+    assert.deepEqual(
+      toggleRecipeInMenu.recipes.map((r) => r.recipe.title).sort(),
+      ['Dessert Tart', 'Main Roast', 'Starter Soup'],
+    );
+  });
+
+  it('toggle removes a recipe when it is already in the menu', async () => {
+    const r1 = await gql<{ createRecipe: { id: string } }>(CREATE_RECIPE, {
+      title: 'Toggleable',
+    });
+    const { createMenu } = await gql<{ createMenu: { id: string } }>(
+      CREATE_MENU,
+      {
+        title: 'Toggle Menu',
+        recipes: [{ recipeId: r1.createRecipe.id }],
+      },
+    );
+
+    // First toggle: present → remove (length 0)
+    const off = await gql<{
+      toggleRecipeInMenu: { recipes: unknown[] };
+    }>(TOGGLE, { menuId: createMenu.id, recipeId: r1.createRecipe.id });
+    assert.equal(off.toggleRecipeInMenu.recipes.length, 0);
+
+    // Second toggle: absent → add back (length 1)
+    const on = await gql<{
+      toggleRecipeInMenu: { recipes: { recipe: { title: string } }[] };
+    }>(TOGGLE, { menuId: createMenu.id, recipeId: r1.createRecipe.id });
+    assert.deepEqual(on.toggleRecipeInMenu.recipes.map((r) => r.recipe.title), [
+      'Toggleable',
+    ]);
+  });
+
+  it('updates and deletes a menu', async () => {
+    const { createMenu } = await gql<{ createMenu: { id: string } }>(
+      CREATE_MENU,
+      { title: 'Draft', recipes: [] },
+    );
+    const { updateMenu } = await gql<{ updateMenu: { title: string } | null }>(
+      UPDATE,
+      { id: createMenu.id, title: 'Finalized' },
+    );
+    assert.equal(updateMenu?.title, 'Finalized');
+
+    await gql(DELETE, { id: createMenu.id });
+    const { menus } = await gql<{ menus: { title: string }[] }>(LIST);
+    assert.ok(!menus.some((m) => m.title === 'Finalized'));
+  });
+});

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/integration/recipe-lifecycle.test.ts
+++ b/tests/integration/recipe-lifecycle.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { gql } from './helpers/gql.ts';
+import { resetDb } from './helpers/reset.ts';
+
+const CREATE = `
+  mutation Create($title: String!) {
+    createRecipe(title: $title, instructions: "x", ingredients: []) {
+      id queued lastMadeAt
+    }
+  }
+`;
+const TOGGLE = `
+  mutation Toggle($id: String!) {
+    toggleRecipeQueued(id: $id) { id queued }
+  }
+`;
+const COMPLETE = `
+  mutation Complete($id: String!) {
+    completeRecipe(id: $id) { id lastMadeAt }
+  }
+`;
+
+describe('recipe lifecycle', () => {
+  beforeEach(() => resetDb());
+
+  it('toggles queued on and off', async () => {
+    const { createRecipe } = await gql<{
+      createRecipe: { id: string; queued: boolean };
+    }>(CREATE, { title: 'Roast Chicken' });
+    assert.equal(createRecipe.queued, false);
+
+    const t1 = await gql<{ toggleRecipeQueued: { queued: boolean } }>(TOGGLE, {
+      id: createRecipe.id,
+    });
+    assert.equal(t1.toggleRecipeQueued.queued, true);
+
+    const t2 = await gql<{ toggleRecipeQueued: { queued: boolean } }>(TOGGLE, {
+      id: createRecipe.id,
+    });
+    assert.equal(t2.toggleRecipeQueued.queued, false);
+  });
+
+  it('stamps lastMadeAt to a recent timestamp on completeRecipe', async () => {
+    const { createRecipe } = await gql<{
+      createRecipe: { id: string; lastMadeAt: string | null };
+    }>(CREATE, { title: 'Lentil Soup' });
+    assert.equal(createRecipe.lastMadeAt, null);
+
+    const { completeRecipe } = await gql<{
+      completeRecipe: { lastMadeAt: string | null };
+    }>(COMPLETE, { id: createRecipe.id });
+
+    assert.notEqual(completeRecipe.lastMadeAt, null);
+    const dt = new Date(completeRecipe.lastMadeAt!).getTime();
+    assert.ok(Date.now() - dt < 10_000);
+  });
+});

--- a/tests/integration/recipes.test.ts
+++ b/tests/integration/recipes.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { gql } from './helpers/gql.ts';
+import { resetDb } from './helpers/reset.ts';
+
+const CREATE = `
+  mutation Create(
+    $title: String!,
+    $instructions: String!,
+    $ingredients: [RecipeIngredientInput!]!,
+    $tags: [String!],
+  ) {
+    createRecipe(
+      title: $title,
+      instructions: $instructions,
+      ingredients: $ingredients,
+      tags: $tags,
+    ) {
+      id slug title tags
+      ingredients { ingredientName quantity unit }
+    }
+  }
+`;
+
+const FETCH = `
+  query Fetch($id: String!) {
+    recipe(id: $id) {
+      id slug title tags
+      ingredients { ingredientName }
+    }
+  }
+`;
+
+const UPDATE = `
+  mutation Update(
+    $id: String!,
+    $title: String,
+    $ingredients: [RecipeIngredientInput!],
+  ) {
+    updateRecipe(id: $id, title: $title, ingredients: $ingredients) {
+      id title
+      ingredients { ingredientName }
+    }
+  }
+`;
+
+const DELETE = `mutation Del($id: String!) { deleteRecipe(id: $id) }`;
+const LIST = `
+  query List($title: String, $tags: [String!]) {
+    recipes(title: $title, tags: $tags) { id title }
+  }
+`;
+
+describe('recipes CRUD', () => {
+  beforeEach(() => resetDb());
+
+  it('creates a recipe with nested ingredients and slugifies the title', async () => {
+    const { createRecipe } = await gql<{
+      createRecipe: {
+        id: string;
+        slug: string;
+        ingredients: { ingredientName: string; quantity: number | null }[];
+      };
+    }>(CREATE, {
+      title: 'Tomato Basil Pasta!',
+      instructions: '1. Boil water\n2. Cook pasta',
+      ingredients: [
+        { ingredientName: 'Pasta', quantity: 200, unit: 'g' },
+        { ingredientName: 'Tomato', quantity: 3 },
+      ],
+      tags: ['italian'],
+    });
+    assert.equal(createRecipe.slug, 'tomato-basil-pasta');
+    assert.equal(createRecipe.ingredients.length, 2);
+  });
+
+  it('fetches a recipe by slug', async () => {
+    await gql(CREATE, {
+      title: 'Greek Salad',
+      instructions: 'Toss',
+      ingredients: [{ ingredientName: 'Feta' }],
+    });
+    const { recipe } = await gql<{
+      recipe: { title: string; ingredients: { ingredientName: string }[] };
+    }>(FETCH, { id: 'greek-salad' });
+    assert.equal(recipe.title, 'Greek Salad');
+    assert.equal(recipe.ingredients[0].ingredientName, 'Feta');
+  });
+
+  it('updates the title and replaces the ingredient list', async () => {
+    const created = await gql<{ createRecipe: { id: string } }>(CREATE, {
+      title: 'Pancakes',
+      instructions: 'Mix',
+      ingredients: [
+        { ingredientName: 'Flour' },
+        { ingredientName: 'Eggs' },
+      ],
+    });
+    const updated = await gql<{
+      updateRecipe: {
+        title: string;
+        ingredients: { ingredientName: string }[];
+      };
+    }>(UPDATE, {
+      id: created.createRecipe.id,
+      title: 'Buttermilk Pancakes',
+      ingredients: [
+        { ingredientName: 'Flour' },
+        { ingredientName: 'Buttermilk' },
+        { ingredientName: 'Eggs' },
+      ],
+    });
+    assert.equal(updated.updateRecipe.title, 'Buttermilk Pancakes');
+    assert.deepEqual(
+      updated.updateRecipe.ingredients.map((i) => i.ingredientName).sort(),
+      ['Buttermilk', 'Eggs', 'Flour'],
+    );
+  });
+
+  it('deletes a recipe and removes it from listings', async () => {
+    const created = await gql<{ createRecipe: { id: string } }>(CREATE, {
+      title: 'Doomed Dish',
+      instructions: 'x',
+      ingredients: [],
+    });
+    const { deleteRecipe } = await gql<{ deleteRecipe: boolean }>(DELETE, {
+      id: created.createRecipe.id,
+    });
+    assert.equal(deleteRecipe, true);
+
+    const { recipes } = await gql<{ recipes: { title: string }[] }>(LIST);
+    assert.ok(!recipes.some((r) => r.title === 'Doomed Dish'));
+  });
+
+  it('filters by tag (array overlap)', async () => {
+    await gql(CREATE, {
+      title: 'Bean Tacos',
+      instructions: 'Wrap',
+      ingredients: [],
+      tags: ['mexican', 'vegetarian'],
+    });
+    await gql(CREATE, {
+      title: 'Beef Tacos',
+      instructions: 'Wrap',
+      ingredients: [],
+      tags: ['mexican'],
+    });
+    await gql(CREATE, {
+      title: 'Tofu Stir Fry',
+      instructions: 'Fry',
+      ingredients: [],
+      tags: ['asian', 'vegetarian'],
+    });
+    const { recipes } = await gql<{ recipes: { title: string }[] }>(LIST, {
+      tags: ['vegetarian'],
+    });
+    assert.deepEqual(recipes.map((r) => r.title).sort(), [
+      'Bean Tacos',
+      'Tofu Stir Fry',
+    ]);
+  });
+
+  it('filters by title substring (ILIKE)', async () => {
+    await gql(CREATE, {
+      title: 'Apple Pie',
+      instructions: 'Bake',
+      ingredients: [],
+    });
+    await gql(CREATE, {
+      title: 'Apple Crumble',
+      instructions: 'Bake',
+      ingredients: [],
+    });
+    await gql(CREATE, {
+      title: 'Cherry Pie',
+      instructions: 'Bake',
+      ingredients: [],
+    });
+    const { recipes } = await gql<{ recipes: { title: string }[] }>(LIST, {
+      title: 'apple',
+    });
+    assert.deepEqual(recipes.map((r) => r.title).sort(), [
+      'Apple Crumble',
+      'Apple Pie',
+    ]);
+  });
+});

--- a/tests/integration/run.ts
+++ b/tests/integration/run.ts
@@ -1,0 +1,271 @@
+import { spawn, execFile, type ChildProcess } from 'node:child_process';
+import { promisify } from 'node:util';
+import { writeFileSync, readFileSync, unlinkSync, readdirSync } from 'node:fs';
+import { createServer, type AddressInfo } from 'node:net';
+import { join } from 'node:path';
+import { once } from 'node:events';
+import { run } from 'node:test';
+import { spec } from 'node:test/reporters';
+import { Client } from 'pg';
+import { startMockServer, type MockServer } from './helpers/mock-server.ts';
+
+const HERE = import.meta.dirname;
+const REPO_ROOT = join(HERE, '..', '..');
+const APP_DIR = join(REPO_ROOT, 'packages', 'app');
+const SCHEMA_SQL = join(APP_DIR, 'schema.sql');
+const HARNESS_FILE = join(HERE, '__harness__.json');
+
+const PG_IMAGE = 'postgres:16-alpine';
+const CONTAINER_NAME = 'pantry-host-integration-pg';
+const PG_USER = 'test';
+const PG_PASSWORD = 'test';
+const PG_DB = 'test';
+
+const exec = promisify(execFile);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function dockerAvailable(): Promise<boolean> {
+  try {
+    await exec('docker', ['info']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function startPostgres(): Promise<{ id: string; port: number; dbUrl: string }> {
+  // Best-effort: clean any leftover from a prior crashed run.
+  await exec('docker', ['rm', '-f', CONTAINER_NAME]).catch(() => {});
+
+  const { stdout: idOut } = await exec('docker', [
+    'run', '-d', '--rm',
+    '--name', CONTAINER_NAME,
+    '-e', `POSTGRES_USER=${PG_USER}`,
+    '-e', `POSTGRES_PASSWORD=${PG_PASSWORD}`,
+    '-e', `POSTGRES_DB=${PG_DB}`,
+    '-P',
+    PG_IMAGE,
+  ]);
+  const id = idOut.trim();
+
+  const { stdout: portOut } = await exec('docker', ['port', id, '5432']);
+  const portMatch = portOut.match(/:(\d+)/);
+  if (!portMatch) throw new Error(`Could not parse mapped Postgres port from: ${portOut}`);
+  const port = parseInt(portMatch[1], 10);
+  const dbUrl = `postgres://${PG_USER}:${PG_PASSWORD}@127.0.0.1:${port}/${PG_DB}`;
+
+  // Probe via the same path tests use — pg_isready inside the container
+  // returns ready before the host port-forward is fully wired, which yields
+  // ECONNRESET on the first real client connection.
+  const deadline = Date.now() + 30_000;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    const client = new Client({ connectionString: dbUrl });
+    try {
+      await client.connect();
+      await client.query('SELECT 1');
+      await client.end();
+      return { id, port, dbUrl };
+    } catch (err) {
+      lastErr = err;
+      await client.end().catch(() => {});
+      await sleep(250);
+    }
+  }
+  throw new Error(`Postgres did not become ready within 30s: ${(lastErr as Error)?.message}`);
+}
+
+async function stopPostgres(id: string): Promise<void> {
+  await exec('docker', ['stop', '-t', '0', id]).catch(() => {});
+}
+
+async function waitForServer(url: string, deadlineMs = 30_000): Promise<void> {
+  const start = Date.now();
+  let lastErr: unknown;
+  while (Date.now() - start < deadlineMs) {
+    try {
+      const r = await fetch(`${url}/graphql`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ query: '{ __typename }' }),
+      });
+      if (r.ok) {
+        const j = (await r.json()) as { data?: { __typename?: string } };
+        if (j.data?.__typename === 'Query') return;
+      }
+    } catch (err) {
+      lastErr = err;
+    }
+    await sleep(250);
+  }
+  throw new Error(
+    `GraphQL server did not become ready within ${deadlineMs}ms at ${url}` +
+      (lastErr ? `\nLast error: ${(lastErr as Error).message}` : ''),
+  );
+}
+
+interface Handle {
+  containerId: string;
+  mock: MockServer;
+  child: ChildProcess;
+}
+
+async function setup(): Promise<Handle> {
+  if (!(await dockerAvailable())) {
+    console.error('\n✗ Could not reach Docker.');
+    console.error('  The integration test harness provisions a Postgres container via');
+    console.error('  the docker CLI. Start Docker Desktop (or `colima start`) and re-run:');
+    console.error('    npm run test:integration\n');
+    process.exit(1);
+  }
+
+  console.log(`\n[harness] Starting Postgres container (${PG_IMAGE})…`);
+  const { id: containerId, dbUrl } = await startPostgres();
+  console.log(`[harness] Postgres ready: ${dbUrl}`);
+
+  // schema.sql's subquery DEFAULTs on kitchen_id are rejected by modern
+  // Postgres. Every app INSERT supplies kitchen_id explicitly, so stripping
+  // the defaults at apply-time is safe.
+  console.log('[harness] Applying schema.sql…');
+  const sanitized = readFileSync(SCHEMA_SQL, 'utf8').replace(
+    /\s*DEFAULT\s*\(\s*SELECT[^)]*\)/gi,
+    '',
+  );
+  const client = new Client({ connectionString: dbUrl });
+  await client.connect();
+  try {
+    await client.query(sanitized);
+    // Quiets the NOTICE chatter the server's IF NOT EXISTS re-adds emit.
+    await client.query(`ALTER DATABASE "${PG_DB}" SET client_min_messages = warning`);
+  } finally {
+    await client.end();
+  }
+
+  console.log('[harness] Starting mock HTTP server…');
+  const mock = await startMockServer();
+  console.log(`[harness] Mock server ready: ${mock.url}`);
+
+  const port = await getFreePort();
+  const url = `http://127.0.0.1:${port}`;
+  console.log(`[harness] Spawning GraphQL server on :${port}…`);
+  const child = spawn('npx', ['tsx', 'graphql-server.ts'], {
+    cwd: APP_DIR,
+    env: {
+      ...process.env,
+      DATABASE_URL: dbUrl,
+      GRAPHQL_PORT: String(port),
+      ANTHROPIC_BASE_URL: mock.url,
+      AI_API_KEY: 'test-key-anthropic-mock',
+      ENABLE_IMAGE_PROCESSING: 'false',
+      NODE_ENV: 'test',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const prefix = (chunk: Buffer) => {
+    for (const line of chunk.toString().split('\n')) {
+      if (line.trim()) process.stderr.write(`[server] ${line}\n`);
+    }
+  };
+  child.stdout?.on('data', prefix);
+  child.stderr?.on('data', prefix);
+  child.on('exit', (code, signal) => {
+    // 143 = SIGTERM (expected on teardown).
+    if (code != null && code !== 0 && code !== 143) {
+      console.error(`[harness] Server exited unexpectedly (code=${code}, signal=${signal})`);
+    }
+  });
+
+  try {
+    await waitForServer(url);
+  } catch (err) {
+    child.kill('SIGTERM');
+    await mock.stop().catch(() => {});
+    await stopPostgres(containerId);
+    throw err;
+  }
+  console.log('[harness] Server ready.\n');
+
+  writeFileSync(
+    HARNESS_FILE,
+    JSON.stringify(
+      {
+        url,
+        dbUrl,
+        mockUrl: mock.url,
+        serverPid: child.pid,
+        containerId,
+        containerName: CONTAINER_NAME,
+        dbName: PG_DB,
+        dbUser: PG_USER,
+      },
+      null,
+      2,
+    ),
+  );
+
+  return { containerId, mock, child };
+}
+
+async function teardown(h: Handle): Promise<void> {
+  if (h.child && !h.child.killed) {
+    h.child.kill('SIGTERM');
+    await sleep(300);
+    if (!h.child.killed) h.child.kill('SIGKILL');
+  }
+  await h.mock.stop().catch((err) => console.error('[harness] mock stop failed:', err));
+  await stopPostgres(h.containerId);
+  try {
+    unlinkSync(HARNESS_FILE);
+  } catch { /* gone already */ }
+}
+
+function discoverTestFiles(): string[] {
+  return readdirSync(HERE)
+    .filter((f) => f.endsWith('.test.ts'))
+    .map((f) => join(HERE, f))
+    .sort();
+}
+
+async function main(): Promise<void> {
+  const handle = await setup();
+  let failed = 0;
+
+  try {
+    const stream = run({
+      files: discoverTestFiles(),
+      concurrency: false,
+    });
+
+    stream.on('test:fail', (event) => {
+      if (event.data.details?.error) failed++;
+    });
+
+    const reporter = stream.compose(spec);
+    reporter.pipe(process.stdout);
+    await once(reporter, 'end');
+  } finally {
+    await teardown(handle);
+  }
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/integration/smoke.test.ts
+++ b/tests/integration/smoke.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { gql } from './helpers/gql.ts';
+
+describe('smoke', () => {
+  it('GraphQL endpoint responds with schema introspection', async () => {
+    const data = await gql<{
+      __schema: {
+        queryType: { name: string };
+        mutationType: { name: string } | null;
+      };
+    }>(`{ __schema { queryType { name } mutationType { name } } }`);
+    assert.equal(data.__schema.queryType.name, 'Query');
+    assert.equal(data.__schema.mutationType?.name, 'Mutation');
+  });
+
+  it('Query.kitchens returns the seeded home kitchen', async () => {
+    const data = await gql<{ kitchens: { slug: string; name: string }[] }>(
+      `{ kitchens { slug name } }`,
+    );
+    const home = data.kitchens.find((k) => k.slug === 'home');
+    assert.ok(home, 'home kitchen present');
+    assert.equal(home.name, 'Home');
+  });
+
+  // Bluesky / AT Protocol is UI-only — no GraphQL surface to integration-test.
+});

--- a/tests/integration/upload.test.ts
+++ b/tests/integration/upload.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { harness } from './helpers/harness.ts';
+import { unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Minimal valid 1x1 transparent PNG.
+const PNG_1X1 = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41,
+  0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00,
+  0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+  0x42, 0x60, 0x82,
+]);
+
+const UPLOADS_DIR = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'packages',
+  'app',
+  'public',
+  'uploads',
+);
+
+describe('POST /upload', () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const filename of created) {
+      try {
+        unlinkSync(join(UPLOADS_DIR, filename));
+      } catch {
+        /* file may have been removed by another test step */
+      }
+    }
+    created.length = 0;
+  });
+
+  it('accepts a PNG upload and returns a /uploads/<uuid>.png URL', async () => {
+    const { url } = harness();
+    const form = new FormData();
+    form.append(
+      'file',
+      new Blob([PNG_1X1], { type: 'image/png' }),
+      'test.png',
+    );
+    const r = await fetch(`${url}/upload`, { method: 'POST', body: form });
+    assert.ok(r.ok);
+
+    const data = (await r.json()) as { url: string };
+    assert.match(data.url, /^\/uploads\/[0-9a-f-]{36}\.png$/);
+    created.push(data.url.replace('/uploads/', ''));
+  });
+
+  it('rejects unsupported file extensions', async () => {
+    const { url } = harness();
+    const form = new FormData();
+    form.append(
+      'file',
+      new Blob([Buffer.from('not really a tiff')], { type: 'image/tiff' }),
+      'test.tiff',
+    );
+    const r = await fetch(`${url}/upload`, { method: 'POST', body: form });
+    assert.equal(r.status, 400);
+  });
+
+  it('returns 400 when no file field is present', async () => {
+    const { url } = harness();
+    const form = new FormData();
+    form.append('not-a-file', 'oops');
+    const r = await fetch(`${url}/upload`, { method: 'POST', body: form });
+    assert.equal(r.status, 400);
+  });
+});


### PR DESCRIPTION
This PR adds an integration test suite for the server. 

When running `npm run test:integration`, the project will now use `node:test` and Node's built-in Typescript support to do the following:

1. Start a fresh postgres db in a Docker container, wait for it to be ready, and seed it with schema/ example data
2. Start the server with REST and GraphQL endpoints
3. Run HTTP requests against all endpoints and assert results to verify functionality
4. Shut down the server and postgres db

For external integrations (e.g. Anthropic API for recipe generation feature), the network requests are mocked to provide a stable surface area, and does not require API keys.

This suite is envisioned to be useful as we make changes to the backend, especially in support of #26 but also in general.

No application code has been modified when adding the test suite.