### PR TITLE
release 0.3.0: umbrella version bump (Rust backend, installer, bootable image)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pantry-server"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pantry-host",
-  "version": "0.1.9",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pantry-host",
-      "version": "0.1.9",
+      "version": "0.3.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -6242,7 +6242,7 @@
     },
     "packages/app": {
       "name": "@pantry-host/app",
-      "version": "0.1.9",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -6281,7 +6281,7 @@
     },
     "packages/feed": {
       "name": "@pantry-host/feed",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@atproto/sync": "^0.1.0",
         "better-sqlite3": "^11.0.0",
@@ -6535,7 +6535,7 @@
     },
     "packages/installer-ui": {
       "name": "@pantry-host/installer-ui",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@pantry-host/shared": "*",
@@ -6564,7 +6564,7 @@
     },
     "packages/marketing": {
       "name": "@pantry-host/marketing",
-      "version": "0.1.9",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@pantry-host/shared": "*",
@@ -6592,7 +6592,7 @@
     },
     "packages/mcp": {
       "name": "@pantry-host/mcp",
-      "version": "0.1.9",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -6610,7 +6610,7 @@
     },
     "packages/shared": {
       "name": "@pantry-host/shared",
-      "version": "0.1.9",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
@@ -6626,7 +6626,7 @@
     },
     "packages/web": {
       "name": "@pantry-host/web",
-      "version": "0.1.9",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@pantry-host/shared": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pantry-host",
-  "version": "0.1.9",
+  "version": "0.3.0",
   "private": true,
   "license": "MIT",
   "workspaces": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pantry-host/app",
-  "version": "0.1.9",
+  "version": "0.3.0",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/packages/feed/package.json
+++ b/packages/feed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pantry-host/feed",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "start": "npx tsx src/server.ts",

--- a/packages/installer-ui/package.json
+++ b/packages/installer-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pantry-host/installer-ui",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/marketing/package.json
+++ b/packages/marketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pantry-host/marketing",
-  "version": "0.1.9",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pantry-host/mcp",
-  "version": "0.1.9",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pantry-server"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pantry-host/shared",
-  "version": "0.1.9",
+  "version": "0.3.0",
   "private": true,
   "license": "MIT",
   "main": "src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pantry-host/web",
-  "version": "0.1.9",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Umbrella version bump folding every workspace manifest + the `pantry-server` crate to a single **0.3.0**, the next release after `v0.2.0`.

## Why
- The manifests had drifted apart: root + app/shared/web/marketing/mcp at `0.1.9`, `feed` at `0.2.0`, and the new `installer-ui` + `pantry-server` at `0.1.0` — while the live git tag was already `v0.2.0`. The `v0.2.0` release skipped the `package.json` bump, so nothing matched the tag.
- This collapses the spread into one umbrella version and makes the manifests agree with what will be tagged.

## What changed
| Package | Before | After |
|---|---|---|
| root + app/shared/web/marketing/mcp | 0.1.9 | **0.3.0** |
| feed | 0.2.0 | **0.3.0** |
| installer-ui | 0.1.0 | **0.3.0** |
| pantry-server (Cargo) | 0.1.0 | **0.3.0** |

Lockfiles reconciled: `package-lock.json` via `npm install --package-lock-only` (version fields only, no incidental churn) and `Cargo.lock` (single line; `cargo check --locked` passes). `packages/image` has no manifest — nothing to bump.

## Why 0.3.0 (not a patch)
Headline changes accumulated since `v0.2.0` are major, not fixes:
- Rust GraphQL backend (`packages/server`) — axum + async-graphql + rusqlite, drop-in for the Node graphql-server, single-binary Pi deploy
- First-boot installer-UI wizard (`packages/installer-ui`)
- Bootable Pi Zero W image builder (`packages/image`)
- Postgres → SQLite switch (#28) + integration test suite (#27)

## Note
No release tag is created by this PR. Tag `v0.3.0` to be cut on the merge commit after approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)