### PR TITLE
fix(web): scroll to #stage element on nav, not document top (mobile)

### DIFF
--- a/packages/web/src/Layout.tsx
+++ b/packages/web/src/Layout.tsx
@@ -85,18 +85,21 @@ export default function Layout() {
   }, [location.pathname]);
 
   // Scroll to #stage on route change — React Router doesn't handle hash
-  // scrolling. Use window.scrollTo (not scrollIntoView) so the reset is
-  // instant and document-level — survives the layout shift when a new
-  // route renders a loading skeleton first and then swaps in the real
-  // content (e.g. the /import/{source}/{id} preview pages). Double-RAF
-  // ensures React's commit + style recalc are done before we scroll.
-  // `#stage` is always at document top in this Layout, so (0,0) is the
-  // same target without depending on the element being measurable.
+  // scrolling. Target the element with an *instant* scrollIntoView: on
+  // narrow viewports the header carries `min-h-[100svh]` (a full-height
+  // hero), so `#stage` is NOT at document top — scrolling to (0,0) leaves
+  // the user stranded on the hero, one viewport above the content. An
+  // instant (behavior: 'auto') scrollIntoView still survives the loading
+  // -skeleton layout shift that motivated the old (0,0) reset — #stage's
+  // own top is stable (it sits directly under the fixed-height header),
+  // it's the skeleton *inside* it that shifts — while also honoring the
+  // element's `scroll-mt-20` clearance. Double-RAF ensures React's commit
+  // + style recalc are done before we measure.
   useEffect(() => {
     if (location.hash === '#stage') {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+          document.getElementById('stage')?.scrollIntoView({ behavior: 'auto' });
         });
       });
     }


### PR DESCRIPTION
## The bug

On the Tier 1 PWA (`my.pantryhost.app`), clicking a `#stage` nav link (or navigating in-app) on a **narrow viewport** left the user parked at scroll position 0 — stranded on the full-height hero — instead of jumping to the content. Reproduced on production at mobile width: after navigating to `/recipes#stage`, `scrollY` was `0` while `#stage` sat `812px` (one viewport) below.

## Root cause

`packages/web/src/Layout.tsx`'s route-change scroll handler scrolled to `(0,0)`, justified by a comment claiming "`#stage` is always at document top in this Layout." That premise is false on mobile: the `<header>` carries `min-h-[100svh] sm:min-h-0`, so a full-viewport hero sits **above** `<main id="stage">` on narrow screens. Scrolling to `(0,0)` *is* the hero.

Desktop was unaffected — no hero there, so `(0,0)` happened to coincide with `#stage`'s top — which is why this survived unnoticed.

**Regression from #24** (`68e3703`): the handler originally used `scrollIntoView`, and #24 swapped it for `(0,0)` to fix a *smooth-scroll* race against loading skeletons on import-preview pages. That fix was overbroad — it threw out element targeting when the actual culprit was the `'smooth'` animation. The real fix is element targeting with an **instant** scroll.

## The fix

```diff
-          window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+          document.getElementById('stage')?.scrollIntoView({ behavior: 'auto' });
```

- Still survives the skeleton layout shift #24 cared about: `#stage`'s own top is stable (it sits directly under the fixed-height header) — only the skeleton content *inside* it shifts.
- Additionally honors the element's `scroll-mt-20` clearance, which `(0,0)` ignored.
- The two same-page click handlers just below already use `scrollIntoView`; this brings the route-change effect back in line with them.

## Verification

Verified in the web dev server at mobile viewport (375×812):
- The effect fires with `location.hash === '#stage'` after navigation ✓
- Manual `#stage.scrollIntoView({behavior:'auto'})` scrolls `812 → 80` (honoring `scroll-mt-20`) and is stable — no reset ✓
- `tsc --noEmit` clean on the changed file

> **Note on the RAF path:** the scroll runs inside a double-`requestAnimationFrame`, which is throttled in hidden/background tabs — including the automation browser used here (`document.visibilityState === 'hidden'`), so the effect's *automated* end-to-end scroll couldn't be driven in-harness. The scroll *operation* itself (target + `behavior:'auto'` + `scroll-mt-20`) is proven by the manual call above; the double-RAF scaffolding is unchanged from the previously-working code and fires normally in a real foreground browser. Worth a quick manual check on a phone before/after merge.

## Not in scope
The double-RAF timing mechanism is left as-is (it's the existing, working approach). If we later want the scroll to be robust against RAF throttling, `packages/app`'s `_app.tsx` uses a `setTimeout` retry fallback — a candidate follow-up, but not this targeted fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)