### PR TITLE
Cross-device publish state: deterministic rkeys + PDS reconcile

### DIFF
--- a/packages/shared/src/atproto-publish.ts
+++ b/packages/shared/src/atproto-publish.ts
@@ -1,8 +1,13 @@
 /**
  * AT Protocol publish client — turns a Pantry Host recipe or menu
  * into an `exchange.recipe.{recipe,collection}` record and pushes
- * it to the signed-in user's PDS via `com.atproto.repo.createRecord`
- * (or `putRecord` on re-publish).
+ * it to the signed-in user's PDS via `com.atproto.repo.putRecord` at
+ * a deterministic rkey derived from the local id (`rkeyForLocal`), so
+ * publish is idempotent: first publish and every re-publish target
+ * one record. Any device can find an already-published record by
+ * reading `getRecord(did, collection, rkeyForLocal(id))` — see
+ * `findPublishedRecord` — which is how the CTA reflects publish state
+ * across devices without a shared database.
  *
  * Dry-run is the default. Set `VITE_ATPROTO_PUBLISH_DRY_RUN=false`
  * (web) or `ATPROTO_PUBLISH_DRY_RUN=false` (app) to actually push
@@ -454,18 +459,18 @@ export async function publishRecipe(
   const embed = await buildPhotoEmbed(recipe, opts);
   if (embed) record.embed = embed;
 
-  const res = opts.rkey
-    ? await opts.agent.com.atproto.repo.putRecord({
-        repo: opts.agent.did,
-        collection: LEXICON_RECIPE,
-        rkey: opts.rkey,
-        record: { ...record, $type: LEXICON_RECIPE },
-      })
-    : await opts.agent.com.atproto.repo.createRecord({
-        repo: opts.agent.did,
-        collection: LEXICON_RECIPE,
-        record: { ...record, $type: LEXICON_RECIPE },
-      });
+  // Deterministic rkey (from the local id) unless an explicit rkey is
+  // given. putRecord creates-or-overwrites, so first publish and every
+  // re-publish hit one record — no duplicate on a second device or a
+  // cleared cache. `opts.rkey` still wins for records published before
+  // this change (their original rkey rides in on the localStorage receipt).
+  const rkey = opts.rkey ?? rkeyForLocal(recipe.id);
+  const res = await opts.agent.com.atproto.repo.putRecord({
+    repo: opts.agent.did,
+    collection: LEXICON_RECIPE,
+    rkey,
+    record: { ...record, $type: LEXICON_RECIPE },
+  });
   return { uri: res.data.uri, cid: res.data.cid, dryRun: false, record };
 }
 
@@ -516,8 +521,10 @@ export async function publishCollection(
         }
       }
     }
-    // Inline publish
-    const res = await publishRecipe(r, opts);
+    // Inline publish — never inherit the menu's rkey (that would write
+    // every child to the menu's key). Each child gets its own
+    // deterministic rkey keyed to the recipe id.
+    const res = await publishRecipe(r, { ...opts, rkey: undefined });
     recipePublishes.push({ recipeId: r.id, result: res, ref: { uri: res.uri, cid: res.cid } });
   }
 
@@ -536,18 +543,13 @@ export async function publishCollection(
     };
   }
 
-  const res = opts.rkey
-    ? await opts.agent.com.atproto.repo.putRecord({
-        repo: opts.agent.did,
-        collection: LEXICON_COLLECTION,
-        rkey: opts.rkey,
-        record: { ...collectionRecord, $type: LEXICON_COLLECTION },
-      })
-    : await opts.agent.com.atproto.repo.createRecord({
-        repo: opts.agent.did,
-        collection: LEXICON_COLLECTION,
-        record: { ...collectionRecord, $type: LEXICON_COLLECTION },
-      });
+  const rkey = opts.rkey ?? rkeyForLocal(menu.id);
+  const res = await opts.agent.com.atproto.repo.putRecord({
+    repo: opts.agent.did,
+    collection: LEXICON_COLLECTION,
+    rkey,
+    record: { ...collectionRecord, $type: LEXICON_COLLECTION },
+  });
   return {
     recipePublishes,
     collection: { uri: res.data.uri, cid: res.data.cid, dryRun: false, record: collectionRecord },
@@ -574,4 +576,49 @@ export async function unpublish(atUri: string, opts: PublishOptions): Promise<{ 
 export function rkeyFromUri(atUri: string): string | null {
   const parts = atUri.replace(/^at:\/\//, '').split('/');
   return parts.length === 3 ? parts[2] : null;
+}
+
+/** Deterministic record key derived from a local recipe/menu id.
+ *  The same local id always maps to the same rkey on the PDS, so a
+ *  first publish and every re-publish target one record — no
+ *  duplicates — and any device that knows the local id can find the
+ *  published record by reading `getRecord(did, collection, rkey)`
+ *  without a stored receipt. Local ids are UUIDs, which are already
+ *  valid rkeys; sanitize + length-cap defensively for any other id
+ *  scheme (rkey syntax: 1–512 of [A-Za-z0-9._~:-], never "." / ".."). */
+export function rkeyForLocal(localId: string): string {
+  const safe = localId.replace(/[^A-Za-z0-9._~:-]/g, '-').slice(0, 512);
+  return safe === '' || safe === '.' || safe === '..' ? `ph-${safe || 'x'}` : safe;
+}
+
+/** Does a record still exist at this AT URI? Public read (no auth).
+ *  Used to reconcile a stored receipt against PDS reality — e.g. the
+ *  record was deleted from another client. */
+export async function recordExists(atUri: string): Promise<boolean> {
+  const parts = atUri.replace(/^at:\/\//, '').split('/');
+  if (parts.length !== 3) return false;
+  try {
+    await getRecord<unknown>(parts[0], parts[1], parts[2]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Look up whether a local recipe/menu is already published on a
+ *  DID's PDS, by its deterministic rkey. Returns the live
+ *  `{ uri, cid }` if present, or null (including on 404). Powers
+ *  cross-device CTA state: a second device resolves the same rkey
+ *  and adopts the record without ever having a local receipt. */
+export async function findPublishedRecord(
+  did: string,
+  collection: string,
+  localId: string,
+): Promise<{ uri: string; cid: string } | null> {
+  try {
+    const rec = await getRecord<unknown>(did, collection, rkeyForLocal(localId));
+    return { uri: rec.uri, cid: rec.cid };
+  } catch {
+    return null;
+  }
 }

--- a/packages/shared/src/components/PublishToBlueskyButton.tsx
+++ b/packages/shared/src/components/PublishToBlueskyButton.tsx
@@ -17,7 +17,7 @@
  * so the UI is honest about what's about to happen.
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Butterfly, CaretDown } from '@phosphor-icons/react';
 import BlueskySignInModal from './BlueskySignInModal';
 import PublishPreviewModal, {
@@ -28,9 +28,13 @@ import { useBlueskyAuth } from '../contexts/BlueskyAuth';
 import {
   buildCollectionRecord,
   buildRecipeRecord,
+  findPublishedRecord,
   isDryRun,
+  LEXICON_COLLECTION,
+  LEXICON_RECIPE,
   publishCollection,
   publishRecipe,
+  recordExists,
   rkeyFromUri,
   unpublish,
   type PublishableMenu,
@@ -88,6 +92,54 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
   );
 
   const dry = isDryRun();
+
+  // Reconcile local state against the PDS (the real cross-device source
+  // of truth) once the session is ready. Runs at most once per item per
+  // sign-in. localStorage is a fast optimistic cache; the PDS decides.
+  //  - a real receipt that no longer resolves (deleted elsewhere) is cleared
+  //  - with no receipt, a record at the deterministic rkey is adopted,
+  //    so a second device / cleared cache shows "View on Bluesky"
+  // Skipped in dry-run: synthetic receipts don't resolve on any PDS.
+  const reconciledRef = useRef(false);
+  useEffect(() => {
+    if (dry || !isSignedIn || !agent) return;
+    if (reconciledRef.current) return;
+    reconciledRef.current = true;
+    const did = (agent as unknown as PublishAgent).did;
+    const collection = props.kind === 'recipe' ? LEXICON_RECIPE : LEXICON_COLLECTION;
+    const local = getPublishReceipt(props.kind, id);
+    let cancelled = false;
+    (async () => {
+      if (local && !local.dryRun) {
+        const stillThere = await recordExists(local.uri);
+        if (cancelled) return;
+        if (!stillThere) {
+          clearPublishReceipt(props.kind, id);
+          setReceipt(null);
+        }
+        return;
+      }
+      if (!local) {
+        const found = await findPublishedRecord(did, collection, id);
+        if (cancelled || !found) return;
+        const adopted: PublishReceipt = {
+          uri: found.uri,
+          cid: found.cid,
+          publishedAt: new Date().toISOString(),
+          handle: handle ?? '',
+          dryRun: false,
+        };
+        setPublishReceipt(props.kind, id, adopted);
+        setReceipt(adopted);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // id/kind identify the item; agent+isSignedIn gate readiness. receipt
+    // is intentionally excluded — the ref guards against re-runs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSignedIn, agent, id, props.kind, dry]);
 
   /** A receipt only counts as "already on the PDS" if it came from a
    *  real publish — or if this run is itself a dry run (all pretend,


### PR DESCRIPTION
Follow-up to #33. Publish state was a per-browser `localStorage` receipt, which meant:
- a **second device** showed "Share to Bluesky" for an already-published recipe — and re-publishing there minted a **duplicate** record;
- an **external delete** (from another AT client) left a dead "View on Bluesky" pointing at a URI that no longer resolves.

Rather than persist state in the app DB (which only helps the shared-DB self-hosted tier, requires a schema migration touching Rust + Node + web, and still drifts from PDS reality), this reads the actual source of truth — **the user's PDS**.

## Changes (`packages/shared`)

**Deterministic rkeys** (`rkeyForLocal`, `atproto-publish.ts`) — publishes now always `putRecord` at an rkey derived from the local recipe/menu id. First publish and every re-publish target **one** record, so a second device (or a cleared cache) can't create a duplicate. Records published *before* this change keep their original rkey via the localStorage receipt (`opts.rkey` still wins).

**PDS reconcile** (`PublishToBlueskyButton.tsx`) — on sign-in, once per item, non-dry-run:
- a stored receipt is verified against the PDS (`recordExists`) and **cleared if the record was deleted elsewhere**;
- with no receipt, a record found at the deterministic rkey (`findPublishedRecord`) is **adopted**, so a fresh device shows "View on Bluesky".
- localStorage stays as a fast optimistic cache; the PDS decides. Both helpers are public `getRecord` reads (no auth).

**Latent bug fixed** — `publishCollection` passed the *menu's* rkey down to inline child recipe publishes, so a menu re-publish would overwrite the menu's key with each child. Children now get their own deterministic rkey.

## Verified

Stub-agent + real-PDS runtime test:
- first publish → `putRecord` at `rkey = id`, `createRecord` never called
- re-publish honors an explicit legacy (TID) rkey → old records aren't orphaned
- collection: children publish to `child-A`/`child-B`, collection to the menu key (bug fix confirmed)
- `recordExists` true on the live Wine Night collection, false on a bogus rkey; `findPublishedRecord` null when absent
- both tiers typecheck at baseline (web 50 / app 119, unchanged); `vite build` passes

## Scope notes

- **Tier 1 (web) cross-device is inherently partial**: OPFS recipe ids differ per device, so two independently-created copies of "the same" recipe can't be unified — but each device is now idempotent and reflects real PDS state.
- **Records published before this PR** (e.g. the existing Wine Night set, at TID rkeys) still dedup on re-publish from the *same* browser via their receipt; cross-device they'd match only after being re-published under a deterministic rkey. Finite, known, not worth a migration.

Separately filed: the self-hosted OAuth gap (real publishing only works via `127.0.0.1` loopback today) — see the linked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)