### PR TITLE
Publish broker: self-hosted Share to Bluesky via hosted-origin popup

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,67 +4,100 @@
     {
       "name": "pantry-host",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && set -a && source .env.local && export DEFAULT_THEME=claude && set +a && npx @limlabs/rex dev --root packages/app --host 0.0.0.0"],
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && set -a && source .env.local && export DEFAULT_THEME=claude && set +a && npx @limlabs/rex dev --root packages/app --host 0.0.0.0"
+      ],
       "port": 3000
     },
     {
       "name": "pantry-host-mini-prod",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && set -a && source .env.local && export DEFAULT_THEME=claude && export PUBLIC_API_ORIGIN=http://100.125.77.118:4001 && set +a && cd packages/app && npx @limlabs/rex start --host 0.0.0.0"],
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && set -a && source .env.local && export DEFAULT_THEME=claude && export PUBLIC_API_ORIGIN=http://100.125.77.118:4001 && set +a && cd packages/app && npx @limlabs/rex start --host 0.0.0.0"
+      ],
       "port": 3000
     },
     {
       "name": "graphql-server",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/app && set -a && source ../../.env.local && set +a && npx tsx graphql-server.ts"],
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/app && set -a && source ../../.env.local && set +a && npx tsx graphql-server.ts"
+      ],
       "port": 4001
     },
     {
       "name": "graphql-server-local",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/app && set -a && source ../../.env.local && export SQLITE_DB_PATH=./pantry.db && set +a && npx tsx graphql-server.ts"],
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/app && set -a && source ../../.env.local && export SQLITE_DB_PATH=./pantry.db && set +a && npx tsx graphql-server.ts"
+      ],
       "port": 4001
     },
     {
       "name": "marketing",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/marketing && npx vite --port 5173"],
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/marketing && npx vite --port 5173"
+      ],
       "port": 5173
     },
     {
       "name": "marketing-prod",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/marketing && npx vite preview --port 5173 --strictPort"],
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/marketing && npx vite preview --port 5173 --strictPort"
+      ],
       "port": 5173
     },
     {
       "name": "web",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/web && npx vite --port 5174"],
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/web && npx vite --port 5174 --host"
+      ],
       "port": 5174
     },
     {
       "name": "mcp-server",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/mcp && set -a && source ../../.env.local && set +a && npx tsx src/index.ts --http"],
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/mcp && set -a && source ../../.env.local && set +a && npx tsx src/index.ts --http"
+      ],
       "port": 5001
     },
     {
       "name": "pantry-host-prod",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && set -a && source .env.local && export DEFAULT_THEME=claude && set +a && cd packages/app && rex build && rex start --host 0.0.0.0"],
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && set -a && source .env.local && export DEFAULT_THEME=claude && set +a && cd packages/app && rex build && rex start --host 0.0.0.0"
+      ],
       "port": 3000
     },
     {
       "name": "graphql-server-prod",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/app && set -a && source ../../.env.local && export SQLITE_DB_PATH=./pantry.db && set +a && npx tsx graphql-server.ts"],
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use && cd packages/app && set -a && source ../../.env.local && export SQLITE_DB_PATH=./pantry.db && set +a && npx tsx graphql-server.ts"
+      ],
       "port": 4001
     },
     {
       "name": "graphql-server-rs",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "cd packages/server && set -a && [ -f ../../.env.local ] && source ../../.env.local; export SQLITE_DB_PATH=\"${SQLITE_DB_PATH:-../app/pantry.db}\" && set +a && cargo run"],
+      "runtimeArgs": [
+        "-c",
+        "cd packages/server && set -a && [ -f ../../.env.local ] && source ../../.env.local; export SQLITE_DB_PATH=\"${SQLITE_DB_PATH:-../app/pantry.db}\" && set +a && cargo run"
+      ],
       "port": 4001
     }
   ]

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -71,6 +71,7 @@
     "./components/ImageBoundary": "./src/components/ImageBoundary.tsx",
     "./sql/schema": "./src/sql/schema.ts",
     "./atproto-publish": "./src/atproto-publish.ts",
+    "./atproto-broker": "./src/atproto-broker.ts",
     "./pds-published": "./src/pds-published.ts",
     "./contexts/BlueskyAuth": "./src/contexts/BlueskyAuth.tsx",
     "./components/BlueskyCallback": "./src/components/BlueskyCallback.tsx",

--- a/packages/shared/src/atproto-broker.ts
+++ b/packages/shared/src/atproto-broker.ts
@@ -13,7 +13,7 @@
  *
  *   self-hosted page ──window.open──▶ my.pantryhost.app/publish-broker
  *        │                                   │
- *        │◀───────── ph-broker:ready ────────│  (repeats after OAuth redirects)
+ *        │◀───────── ph-broker:ready ────────│
  *        │────────── ph-broker:request ─────▶│  (payload; Blobs structured-clone)
  *        │                                   │  user reviews + CONFIRMS in popup
  *        │                                   │──▶ PDS (putRecord, browser-side)
@@ -190,9 +190,12 @@ const POPUP_FEATURES = 'width=480,height=760,noopener=no';
  * opens immediately on the click tick, and slow prep (photo Blob
  * collection) resolves while the popup is still loading.
  *
- * The ready→request handshake repeats: if the popup navigates away for
- * OAuth sign-in and comes back, it pings ready again and the payload is
- * re-sent (Blobs and all) — the requester's promise just stays pending.
+ * The broker popup never navigates: OAuth sign-in runs in a NESTED
+ * popup (BlueskyAuth's signInPopup), because the PDS auth pages send
+ * COOP headers that would sever window.opener on a redirect round-trip
+ * and orphan the broker from us. The requester's promise stays pending
+ * across sign-in; the re-send-on-ready handling below is defensive
+ * (e.g. a manual reload of the popup before the request is accepted).
  */
 export function publishViaBroker(
   request: BrokerRequest | Promise<BrokerRequest>,

--- a/packages/shared/src/atproto-broker.ts
+++ b/packages/shared/src/atproto-broker.ts
@@ -144,14 +144,25 @@ export function shouldUseBroker(): boolean {
 // ── Requester-side helpers ───────────────────────────────────────────────
 
 /** Fetch each photoUrl into a Blob from the REQUESTER's context, where
- *  `/uploads/…` paths are same-origin. Failures are skipped — a photo
- *  never blocks a publish (same policy as direct publishing). */
-export async function collectPhotoBlobs(photoUrls: Array<string | null | undefined>): Promise<Record<string, Blob>> {
+ *  `/uploads/…` paths are same-origin. Pass `fetchPhoto` to override
+ *  resolution for schemes plain fetch can't reach — the web PWA's
+ *  `opfs://` photos need its OPFS-aware resolver here just like they
+ *  do for direct publishes. Failures are skipped — a photo never
+ *  blocks a publish (same policy as direct publishing). */
+export async function collectPhotoBlobs(
+  photoUrls: Array<string | null | undefined>,
+  fetchPhoto?: (photoUrl: string) => Promise<Blob | null>,
+): Promise<Record<string, Blob>> {
   const out: Record<string, Blob> = {};
   const unique = [...new Set(photoUrls.filter((u): u is string => !!u))];
   await Promise.all(
     unique.map(async (url) => {
       try {
+        if (fetchPhoto) {
+          const blob = await fetchPhoto(url);
+          if (blob) out[url] = blob;
+          return;
+        }
         const res = await fetch(url);
         if (res.ok) out[url] = await res.blob();
       } catch {

--- a/packages/shared/src/atproto-broker.ts
+++ b/packages/shared/src/atproto-broker.ts
@@ -1,0 +1,240 @@
+/**
+ * Publish broker — lets a self-hosted Pantry Host instance publish to
+ * Bluesky through a popup on the hosted Tier 1 origin
+ * (my.pantryhost.app), where AT Protocol OAuth actually works.
+ *
+ * Why: AT OAuth requires the client_id to be a publicly-fetchable
+ * HTTPS document and web-client redirect URIs to live on that origin.
+ * A LAN / Tailscale / plain-HTTP self-hosted box can't satisfy either,
+ * so it can never complete the OAuth dance itself (see issue #37).
+ * The broker popup runs on the public origin, holds the OAuth session
+ * there, and performs the browser → PDS write on the requester's
+ * behalf. The flow is:
+ *
+ *   self-hosted page ──window.open──▶ my.pantryhost.app/publish-broker
+ *        │                                   │
+ *        │◀───────── ph-broker:ready ────────│  (repeats after OAuth redirects)
+ *        │────────── ph-broker:request ─────▶│  (payload; Blobs structured-clone)
+ *        │                                   │  user reviews + CONFIRMS in popup
+ *        │                                   │──▶ PDS (putRecord, browser-side)
+ *        │◀───────── ph-broker:result ───────│  (receipts, targetOrigin-locked)
+ *
+ * Security invariants (keep these when editing):
+ * - Tokens/DPoP keys NEVER leave the broker origin. Only record
+ *   payloads go in; only receipts come out.
+ * - The broker accepts exactly ONE request per popup lifetime — no
+ *   payload swapping after the confirm UI renders.
+ * - The confirm click happens INSIDE the popup (real URL bar, no
+ *   clickjacking), with the requesting origin displayed prominently.
+ * - Replies use an explicit targetOrigin (the captured requester
+ *   origin), never '*'. The ready ping carries no data, so '*' is
+ *   acceptable there (the popup can't know its opener's origin first).
+ * - No auto-publish: nothing is written without a user gesture in the
+ *   trusted origin.
+ *
+ * The record still travels browser → PDS; Pantry Host infrastructure
+ * stores nothing. The trade-off is availability/trust coupling to the
+ * hosted origin — the fully-sovereign alternatives (own public domain,
+ * app passwords) are tracked in #37.
+ */
+
+import type { PublishableMenu, PublishableRecipe } from './atproto-publish';
+
+// ── Protocol ─────────────────────────────────────────────────────────────
+
+export const BROKER_READY = 'ph-broker:ready';
+export const BROKER_REQUEST = 'ph-broker:request';
+export const BROKER_RESULT = 'ph-broker:result';
+
+export interface BrokerReceipt {
+  uri: string;
+  cid: string;
+  handle: string;
+  dryRun: boolean;
+}
+
+export type BrokerRequest =
+  | {
+      type: typeof BROKER_REQUEST;
+      action: 'publish';
+      kind: 'recipe';
+      recipe: PublishableRecipe;
+      /** Re-publish target for records that predate deterministic
+       *  rkeys — omit to publish at rkeyForLocal(recipe.id). */
+      rkey?: string;
+      /** photoUrl → bytes, fetched by the requester (same-origin
+       *  there; the broker origin can't reach a LAN box). */
+      photoBlobs?: Record<string, Blob>;
+      dryRun: boolean;
+    }
+  | {
+      type: typeof BROKER_REQUEST;
+      action: 'publish';
+      kind: 'menu';
+      menu: PublishableMenu;
+      rkey?: string;
+      /** recipeId → known-good strongRef, so already-published
+       *  children are reused instead of re-published. */
+      existingRefs?: Record<string, { uri: string; cid: string }>;
+      photoBlobs?: Record<string, Blob>;
+      dryRun: boolean;
+    }
+  | {
+      type: typeof BROKER_REQUEST;
+      action: 'unpublish';
+      kind: 'recipe' | 'menu';
+      uri: string;
+      /** Shown in the confirm UI so the user knows what they're deleting. */
+      title: string;
+      dryRun: boolean;
+    };
+
+export type BrokerResult =
+  | {
+      type: typeof BROKER_RESULT;
+      ok: true;
+      action: 'publish';
+      kind: 'recipe' | 'menu';
+      receipt: BrokerReceipt;
+      /** Menu publishes: receipts for children published inline, so
+       *  the requester can persist them for future Reuse. */
+      childReceipts?: Record<string, BrokerReceipt>;
+    }
+  | { type: typeof BROKER_RESULT; ok: true; action: 'unpublish' }
+  | { type: typeof BROKER_RESULT; ok: false; error: 'cancelled' | 'sign-in-failed' | string };
+
+// ── Broker location ──────────────────────────────────────────────────────
+
+export const DEFAULT_BROKER_URL = 'https://my.pantryhost.app/publish-broker';
+
+/** Resolve the broker URL: Vite env (web dev), meta tag (Rex — same
+ *  channel as atproto-publish-dry-run), then the hosted default. */
+export function brokerUrl(): string {
+  try {
+    // @ts-expect-error import.meta.env is a Vite-ism
+    const vite = import.meta?.env?.VITE_ATPROTO_BROKER_URL;
+    if (vite) return String(vite);
+  } catch {
+    /* not vite */
+  }
+  if (typeof document !== 'undefined') {
+    const meta = document.querySelector('meta[name="atproto-broker-url"]')?.getAttribute('content');
+    if (meta) return meta;
+  }
+  return DEFAULT_BROKER_URL;
+}
+
+/** True when this origin cannot complete AT OAuth itself and should
+ *  publish through the broker popup instead: not the spec loopback
+ *  (127.0.0.1 / [::1]) and not an origin the hosted client's
+ *  redirect_uris cover. Deliberately includes `localhost` — the spec
+ *  rejects it for loopback OAuth, but the broker works fine there. */
+export function shouldUseBroker(): boolean {
+  if (typeof window === 'undefined') return false;
+  const { hostname, origin } = window.location;
+  if (hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1') return false;
+  const brokerOrigin = new URL(brokerUrl()).origin;
+  // Direct OAuth works on the hosted origins themselves (and on the
+  // broker origin — a broker popup opening a broker would be silly).
+  if (origin === brokerOrigin) return false;
+  if (origin === 'https://my.pantryhost.app' || origin === 'https://pantryhost.app') return false;
+  return true;
+}
+
+// ── Requester-side helpers ───────────────────────────────────────────────
+
+/** Fetch each photoUrl into a Blob from the REQUESTER's context, where
+ *  `/uploads/…` paths are same-origin. Failures are skipped — a photo
+ *  never blocks a publish (same policy as direct publishing). */
+export async function collectPhotoBlobs(photoUrls: Array<string | null | undefined>): Promise<Record<string, Blob>> {
+  const out: Record<string, Blob> = {};
+  const unique = [...new Set(photoUrls.filter((u): u is string => !!u))];
+  await Promise.all(
+    unique.map(async (url) => {
+      try {
+        const res = await fetch(url);
+        if (res.ok) out[url] = await res.blob();
+      } catch {
+        /* skip — broker will publish without this photo */
+      }
+    }),
+  );
+  return out;
+}
+
+/** How long the requester waits for the user to finish in the popup.
+ *  Generous: sign-in (an OAuth round-trip) can happen mid-flow. */
+const BROKER_TIMEOUT_MS = 5 * 60 * 1000;
+const POPUP_FEATURES = 'width=480,height=760,noopener=no';
+
+/**
+ * Open the broker popup and run one request through it. MUST be called
+ * synchronously from a user gesture (click handler) or popup blockers
+ * eat the window — which is why `request` may be a Promise: the popup
+ * opens immediately on the click tick, and slow prep (photo Blob
+ * collection) resolves while the popup is still loading.
+ *
+ * The ready→request handshake repeats: if the popup navigates away for
+ * OAuth sign-in and comes back, it pings ready again and the payload is
+ * re-sent (Blobs and all) — the requester's promise just stays pending.
+ */
+export function publishViaBroker(
+  request: BrokerRequest | Promise<BrokerRequest>,
+  url = brokerUrl(),
+): Promise<BrokerResult> {
+  const brokerOrigin = new URL(url).origin;
+  const popup = typeof window !== 'undefined' ? window.open(url, 'ph-publish-broker', POPUP_FEATURES) : null;
+  if (!popup) {
+    return Promise.resolve({
+      type: BROKER_RESULT,
+      ok: false,
+      error: 'Popup blocked — allow popups for this site and try again.',
+    });
+  }
+
+  return new Promise<BrokerResult>((resolve) => {
+    let settled = false;
+    const settle = (result: BrokerResult) => {
+      if (settled) return;
+      settled = true;
+      window.removeEventListener('message', onMessage);
+      clearInterval(closedPoll);
+      clearTimeout(deadline);
+      resolve(result);
+    };
+
+    const onMessage = async (event: MessageEvent) => {
+      if (event.origin !== brokerOrigin || event.source !== popup) return;
+      const data = event.data as { type?: string } | null;
+      if (data?.type === BROKER_READY) {
+        // (Re-)send the payload — targetOrigin locked to the broker.
+        try {
+          popup.postMessage(await request, brokerOrigin);
+        } catch (err) {
+          settle({ type: BROKER_RESULT, ok: false, error: err instanceof Error ? err.message : 'Failed to prepare the publish payload.' });
+          popup.close();
+        }
+        return;
+      }
+      if (data?.type === BROKER_RESULT) {
+        settle(data as BrokerResult);
+        popup.close();
+      }
+    };
+    window.addEventListener('message', onMessage);
+
+    // User closed the popup without finishing.
+    const closedPoll = setInterval(() => {
+      if (popup.closed) settle({ type: BROKER_RESULT, ok: false, error: 'cancelled' });
+    }, 500);
+
+    const deadline = setTimeout(() => {
+      settle({ type: BROKER_RESULT, ok: false, error: 'Timed out waiting for the publish window.' });
+      try {
+        popup.close();
+      } catch {
+        /* already gone */
+      }
+    }, BROKER_TIMEOUT_MS);
+  });
+}

--- a/packages/shared/src/atproto-broker.ts
+++ b/packages/shared/src/atproto-broker.ts
@@ -111,8 +111,13 @@ export const DEFAULT_BROKER_URL = 'https://my.pantryhost.app/publish-broker';
  *  channel as atproto-publish-dry-run), then the hosted default. */
 export function brokerUrl(): string {
   try {
+    // Exact `import.meta.env.VITE_X` token required — Vite's env
+    // replacement doesn't recognize optional-chained (`?.`) access,
+    // so that "defensive" spelling silently reads undefined forever.
+    // The try/catch handles non-Vite bundlers (Rex: env is undefined
+    // → TypeError → caught).
     // @ts-expect-error import.meta.env is a Vite-ism
-    const vite = import.meta?.env?.VITE_ATPROTO_BROKER_URL;
+    const vite = import.meta.env.VITE_ATPROTO_BROKER_URL;
     if (vite) return String(vite);
   } catch {
     /* not vite */

--- a/packages/shared/src/atproto-publish.ts
+++ b/packages/shared/src/atproto-publish.ts
@@ -180,8 +180,11 @@ const AUTO_TAG_RE = /^(bluesky|recipe-api|cooklang|mealdb|cocktaildb|publicdomai
 export function isDryRun(): boolean {
   // Vite (web package)
   try {
+    // Exact `import.meta.env.VITE_X` token required — Vite's env
+    // replacement doesn't recognize optional-chained access; the
+    // try/catch covers non-Vite bundlers.
     // @ts-expect-error - import.meta.env is a Vite-ism
-    const viteFlag = import.meta?.env?.VITE_ATPROTO_PUBLISH_DRY_RUN;
+    const viteFlag = import.meta.env.VITE_ATPROTO_PUBLISH_DRY_RUN;
     if (viteFlag !== undefined) return String(viteFlag) !== 'false';
   } catch {
     // import.meta not available (Rex/Node) — fall through

--- a/packages/shared/src/components/BlueskySignInModal.tsx
+++ b/packages/shared/src/components/BlueskySignInModal.tsx
@@ -19,10 +19,16 @@ import { useBlueskyAuth } from '../contexts/BlueskyAuth';
 export interface BlueskySignInModalProps {
   open: boolean;
   onClose: () => void;
+  /** 'redirect' (default) navigates this page through the OAuth
+   *  dance. 'popup' runs OAuth in a nested popup and keeps this page
+   *  alive — required in the publish broker, where navigating would
+   *  sever `window.opener` (PDS auth pages send COOP) and lose the
+   *  in-memory publish request. */
+  mode?: 'redirect' | 'popup';
 }
 
-export default function BlueskySignInModal({ open, onClose }: BlueskySignInModalProps) {
-  const { signIn, isReady, error: ctxError } = useBlueskyAuth();
+export default function BlueskySignInModal({ open, onClose, mode = 'redirect' }: BlueskySignInModalProps) {
+  const { signIn, signInPopup, isReady, error: ctxError } = useBlueskyAuth();
   const [handle, setHandle] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
@@ -32,8 +38,16 @@ export default function BlueskySignInModal({ open, onClose }: BlueskySignInModal
     setLocalError(null);
     setSubmitting(true);
     try {
-      await signIn(handle);
-      // signIn navigates away; this line rarely runs.
+      if (mode === 'popup') {
+        // Resolves once the user finishes in the nested popup; this
+        // page (and modal) stays mounted throughout.
+        await signInPopup(handle);
+        setSubmitting(false);
+        onClose();
+      } else {
+        await signIn(handle);
+        // signIn navigates away; this line rarely runs.
+      }
     } catch (err: any) {
       setLocalError(err?.message ?? 'Sign-in failed');
       setSubmitting(false);
@@ -87,7 +101,7 @@ export default function BlueskySignInModal({ open, onClose }: BlueskySignInModal
               disabled={submitting || !handle.trim() || !isReady}
               className="px-3 py-1.5 text-sm rounded-md bg-[var(--color-accent)] text-[var(--color-bg-body)] font-semibold disabled:bg-[var(--color-bg-card)] disabled:text-[var(--color-text-secondary)] disabled:border disabled:border-[var(--color-border-card)]"
             >
-              {submitting ? 'Redirecting…' : !isReady ? 'Loading…' : 'Continue'}
+              {submitting ? (mode === 'popup' ? 'Waiting for sign-in…' : 'Redirecting…') : !isReady ? 'Loading…' : 'Continue'}
             </button>
           </div>
         </form>

--- a/packages/shared/src/components/PublishToBlueskyButton.tsx
+++ b/packages/shared/src/components/PublishToBlueskyButton.tsx
@@ -118,11 +118,19 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
   const reconciledRef = useRef(false);
   useEffect(() => {
     if (dry || reconciledRef.current) return;
-    const local = getPublishReceipt(props.kind, id);
+    let local = getPublishReceipt(props.kind, id);
+    // A leftover dry receipt (from a previous dry-run session) is
+    // meaningless in real mode — its DRYRUN- record exists nowhere.
+    // Purge it so the CTA doesn't claim a published state that isn't.
+    if (local?.dryRun) {
+      clearPublishReceipt(props.kind, id);
+      setReceipt(null);
+      local = null;
+    }
     let cancelled = false;
 
     if (!isSignedIn || !agent) {
-      if (!viaBroker || !local || local.dryRun) return;
+      if (!viaBroker || !local) return;
       reconciledRef.current = true;
       (async () => {
         const stillThere = await recordExists(local.uri);
@@ -140,7 +148,8 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
     const did = (agent as unknown as PublishAgent).did;
     const collection = props.kind === 'recipe' ? LEXICON_RECIPE : LEXICON_COLLECTION;
     (async () => {
-      if (local && !local.dryRun) {
+      if (local) {
+        // Always a real receipt here — dry ones were purged above.
         const stillThere = await recordExists(local.uri);
         if (cancelled) return;
         if (!stillThere) {
@@ -478,8 +487,10 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
     );
   }
 
-  if (receipt) {
-    // Already published — View + dropdown
+  if (usableReceipt(receipt)) {
+    // Already published — View + dropdown. Gated on usableReceipt,
+    // not the raw receipt: in real mode a leftover dry receipt must
+    // render as "not published", same rule as reuse/rkey above.
     const bskyUrl = atUriToBskyAppUrl(receipt.uri, receipt.handle);
     return (
       <div className="relative inline-flex">

--- a/packages/shared/src/components/PublishToBlueskyButton.tsx
+++ b/packages/shared/src/components/PublishToBlueskyButton.tsx
@@ -400,7 +400,7 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
     const request = (async (): Promise<BrokerRequest> => {
       const rkey = usableReceipt(receipt) ? rkeyFromUri(receipt.uri) ?? undefined : undefined;
       if (props.kind === 'recipe') {
-        const photoBlobs = await collectPhotoBlobs([props.recipe.photoUrl]);
+        const photoBlobs = await collectPhotoBlobs([props.recipe.photoUrl], props.fetchPhoto);
         return { type: BROKER_REQUEST, action: 'publish', kind: 'recipe', recipe: props.recipe, rkey, photoBlobs, dryRun: dry };
       }
       const existingRefs: Record<string, { uri: string; cid: string }> = {};
@@ -408,7 +408,7 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
         const cr = getPublishReceipt('recipe', r.id);
         if (usableReceipt(cr)) existingRefs[r.id] = { uri: cr.uri, cid: cr.cid };
       }
-      const photoBlobs = await collectPhotoBlobs(props.menu.recipes.map((r) => r.photoUrl));
+      const photoBlobs = await collectPhotoBlobs(props.menu.recipes.map((r) => r.photoUrl), props.fetchPhoto);
       return { type: BROKER_REQUEST, action: 'publish', kind: 'menu', menu: props.menu, rkey, existingRefs, photoBlobs, dryRun: dry };
     })();
     setPending(true);

--- a/packages/shared/src/components/PublishToBlueskyButton.tsx
+++ b/packages/shared/src/components/PublishToBlueskyButton.tsx
@@ -47,6 +47,14 @@ import {
   setPublishReceipt,
   type PublishReceipt,
 } from '../pds-published';
+import {
+  BROKER_REQUEST,
+  collectPhotoBlobs,
+  publishViaBroker,
+  shouldUseBroker,
+  type BrokerRequest,
+  type BrokerResult,
+} from '../atproto-broker';
 
 // ── Props ────────────────────────────────────────────────────────────────
 
@@ -92,6 +100,10 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
   );
 
   const dry = isDryRun();
+  // On origins that can't complete AT OAuth themselves (LAN, Tailscale,
+  // plain HTTP — see issue #37), publishing routes through a popup on
+  // the hosted origin instead of the local sign-in + preview modals.
+  const viaBroker = shouldUseBroker();
 
   // Reconcile local state against the PDS (the real cross-device source
   // of truth) once the session is ready. Runs at most once per item per
@@ -100,15 +112,33 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
   //  - with no receipt, a record at the deterministic rkey is adopted,
   //    so a second device / cleared cache shows "View on Bluesky"
   // Skipped in dry-run: synthetic receipts don't resolve on any PDS.
+  // Broker origins have no local session, but `recordExists` is a
+  // public read — stale-receipt cleanup still runs there. Adoption
+  // needs a DID, which only a session provides, so it stays gated.
   const reconciledRef = useRef(false);
   useEffect(() => {
-    if (dry || !isSignedIn || !agent) return;
-    if (reconciledRef.current) return;
+    if (dry || reconciledRef.current) return;
+    const local = getPublishReceipt(props.kind, id);
+    let cancelled = false;
+
+    if (!isSignedIn || !agent) {
+      if (!viaBroker || !local || local.dryRun) return;
+      reconciledRef.current = true;
+      (async () => {
+        const stillThere = await recordExists(local.uri);
+        if (!cancelled && !stillThere) {
+          clearPublishReceipt(props.kind, id);
+          setReceipt(null);
+        }
+      })();
+      return () => {
+        cancelled = true;
+      };
+    }
+
     reconciledRef.current = true;
     const did = (agent as unknown as PublishAgent).did;
     const collection = props.kind === 'recipe' ? LEXICON_RECIPE : LEXICON_COLLECTION;
-    const local = getPublishReceipt(props.kind, id);
-    let cancelled = false;
     (async () => {
       if (local && !local.dryRun) {
         const stillThere = await recordExists(local.uri);
@@ -139,7 +169,7 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
     // id/kind identify the item; agent+isSignedIn gate readiness. receipt
     // is intentionally excluded — the ref guards against re-runs.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSignedIn, agent, id, props.kind, dry]);
+  }, [isSignedIn, agent, id, props.kind, dry, viaBroker]);
 
   /** A receipt only counts as "already on the PDS" if it came from a
    *  real publish — or if this run is itself a dry run (all pretend,
@@ -311,11 +341,114 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
     }
   }
 
+  // ── Broker mode (self-hosted origins that can't do AT OAuth) ──────────
+  // Sign-in, preview, and the confirm click all happen inside the popup
+  // on the hosted origin; this side only sends the payload and stores
+  // the receipts that come back. See shared/atproto-broker.ts.
+
+  function applyBrokerResult(res: BrokerResult) {
+    if (!res.ok) {
+      // A closed popup is a deliberate "no" — not an error to shout about.
+      if (res.error !== 'cancelled') setError(res.error);
+      return;
+    }
+    if (res.action === 'unpublish') {
+      clearPublishReceipt(props.kind, id);
+      setReceipt(null);
+      return;
+    }
+    const now = new Date().toISOString();
+    if (res.childReceipts) {
+      for (const [recipeId, cr] of Object.entries(res.childReceipts)) {
+        setPublishReceipt('recipe', recipeId, {
+          uri: cr.uri,
+          cid: cr.cid,
+          publishedAt: now,
+          handle: cr.handle,
+          dryRun: cr.dryRun,
+        });
+      }
+    }
+    const newReceipt: PublishReceipt = {
+      uri: res.receipt.uri,
+      cid: res.receipt.cid,
+      publishedAt: now,
+      handle: res.receipt.handle,
+      dryRun: res.receipt.dryRun,
+    };
+    setPublishReceipt(props.kind, id, newReceipt);
+    setReceipt(newReceipt);
+    // Open the modal straight onto its confirmation step (AT URI,
+    // copy button, QR) — the popup already closed.
+    setPublishResult({
+      uri: newReceipt.uri,
+      dryRun: newReceipt.dryRun,
+      handle: newReceipt.handle,
+      kind: props.kind === 'recipe' ? 'recipe' : 'collection',
+      inlinePublished: res.childReceipts ? Object.keys(res.childReceipts).length : undefined,
+    });
+    setPreviewOpen(true);
+    props.onPublished?.({ uri: newReceipt.uri, cid: newReceipt.cid, dryRun: newReceipt.dryRun });
+  }
+
+  function handleBrokerPublish() {
+    setError(null);
+    setMenuOpen(false);
+    // publishViaBroker opens the popup synchronously on this click;
+    // the payload promise (photo Blob collection) resolves while the
+    // popup loads and is delivered on its ready ping.
+    const request = (async (): Promise<BrokerRequest> => {
+      const rkey = usableReceipt(receipt) ? rkeyFromUri(receipt.uri) ?? undefined : undefined;
+      if (props.kind === 'recipe') {
+        const photoBlobs = await collectPhotoBlobs([props.recipe.photoUrl]);
+        return { type: BROKER_REQUEST, action: 'publish', kind: 'recipe', recipe: props.recipe, rkey, photoBlobs, dryRun: dry };
+      }
+      const existingRefs: Record<string, { uri: string; cid: string }> = {};
+      for (const r of props.menu.recipes) {
+        const cr = getPublishReceipt('recipe', r.id);
+        if (usableReceipt(cr)) existingRefs[r.id] = { uri: cr.uri, cid: cr.cid };
+      }
+      const photoBlobs = await collectPhotoBlobs(props.menu.recipes.map((r) => r.photoUrl));
+      return { type: BROKER_REQUEST, action: 'publish', kind: 'menu', menu: props.menu, rkey, existingRefs, photoBlobs, dryRun: dry };
+    })();
+    setPending(true);
+    publishViaBroker(request).then((res) => {
+      setPending(false);
+      applyBrokerResult(res);
+    });
+  }
+
+  function handleBrokerUnpublish() {
+    if (!receipt) return;
+    setMenuOpen(false);
+    // Dry receipts never reached a PDS — clear locally, no popup.
+    if (receipt.dryRun) {
+      clearPublishReceipt(props.kind, id);
+      setReceipt(null);
+      return;
+    }
+    setError(null);
+    setPending(true);
+    publishViaBroker({
+      type: BROKER_REQUEST,
+      action: 'unpublish',
+      kind: props.kind,
+      uri: receipt.uri,
+      title: props.kind === 'recipe' ? props.recipe.title : props.menu.title,
+      dryRun: dry,
+    }).then((res) => {
+      setPending(false);
+      applyBrokerResult(res);
+    });
+  }
+
   // ── Render ─────────────────────────────────────────────────────────────
 
   const iconSize = props.compact ? 16 : 18;
 
-  if (!isReady) {
+  // Broker mode has no local session — auth readiness and sign-in live
+  // in the popup, so those gates only apply to the direct flow.
+  if (!viaBroker && !isReady) {
     return (
       <button
         type="button"
@@ -328,7 +461,7 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
     );
   }
 
-  if (!isSignedIn) {
+  if (!viaBroker && !isSignedIn) {
     return (
       <>
         <button
@@ -382,7 +515,12 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
             <button
               type="button"
               role="menuitem"
+              disabled={pending}
               onClick={() => {
+                if (viaBroker) {
+                  handleBrokerPublish();
+                  return;
+                }
                 setMenuOpen(false);
                 setPreviewOpen(true);
               }}
@@ -394,12 +532,17 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
               type="button"
               role="menuitem"
               disabled={pending}
-              onClick={handleUnpublish}
+              onClick={viaBroker ? handleBrokerUnpublish : handleUnpublish}
               className="block w-full text-left px-3 py-1.5 cursor-pointer hover:underline text-[var(--color-danger)]"
             >
               {pending ? 'Unpublishing…' : dry ? 'Unpublish (dry run)' : 'Unpublish'}
             </button>
           </div>
+        )}
+        {viaBroker && error && (
+          <span role="alert" className="absolute left-0 top-full mt-1 text-xs text-[var(--color-danger)] whitespace-nowrap pretty">
+            {error}
+          </span>
         )}
         {previewMode && (
           <PublishPreviewModal
@@ -421,22 +564,29 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
     );
   }
 
-  // Signed in, not yet published
+  // Not yet published: signed in (direct flow) or broker mode (auth
+  // and preview live in the popup on the hosted origin).
   return (
     <>
       <button
         type="button"
-        onClick={() => setPreviewOpen(true)}
+        disabled={pending}
+        onClick={() => (viaBroker ? handleBrokerPublish() : setPreviewOpen(true))}
         className={`btn-secondary ${props.compact ? 'px-3 py-1.5' : ''}`}
       >
         <Butterfly size={iconSize} weight="light" aria-hidden />
-        Share to Bluesky
+        {pending && viaBroker ? 'Waiting for publish window…' : 'Share to Bluesky'}
         {dry && (
           <span className="text-[9px] uppercase tracking-wider px-1 rounded bg-[var(--color-warning-bg)] text-[var(--color-warning)] font-semibold">
             Dry
           </span>
         )}
       </button>
+      {viaBroker && error && (
+        <span role="alert" className="block mt-2 text-xs text-[var(--color-danger)] pretty">
+          {error}
+        </span>
+      )}
       {previewMode && (
         <PublishPreviewModal
           open={previewOpen}

--- a/packages/shared/src/contexts/BlueskyAuth.tsx
+++ b/packages/shared/src/contexts/BlueskyAuth.tsx
@@ -56,6 +56,14 @@ export interface BlueskyAuthState {
   /** Kick off the OAuth redirect. Never resolves in the happy
    *  path — the browser navigates away. Throws if not ready. */
   signIn: (handleInput: string) => Promise<void>;
+  /** Sign in WITHOUT navigating this page: OAuth runs in a nested
+   *  popup and the session lands here via BroadcastChannel. Required
+   *  wherever navigation would destroy in-memory state — the publish
+   *  broker popup MUST use this, because the PDS auth pages send COOP
+   *  headers that permanently sever `window.opener` on a redirect
+   *  round-trip, orphaning the broker from its requester. Resolves
+   *  once signed in. Must be called from a user gesture. */
+  signInPopup: (handleInput: string) => Promise<void>;
   /** Revoke tokens and drop local session state. */
   signOut: () => Promise<void>;
   /** Human-readable status for error toasts / debug. */
@@ -69,6 +77,9 @@ const DEFAULT_STATE: BlueskyAuthState = {
   handle: null,
   agent: null,
   signIn: async () => {
+    throw new Error('BlueskyAuthProvider not mounted');
+  },
+  signInPopup: async () => {
     throw new Error('BlueskyAuthProvider not mounted');
   },
   signOut: async () => {
@@ -269,6 +280,11 @@ export function BlueskyAuthProvider({
         }
         if (!cancelled) setIsReady(true);
       } catch (err: any) {
+        // We're the throwaway callback page of a signInPopup flow:
+        // init() already handed the session to the opening window via
+        // BroadcastChannel and the opener is about to close us. Not an
+        // error — just don't flash one while we're being closed.
+        if (err?.code === 'LOGIN_CONTINUED_IN_PARENT_WINDOW') return;
         if (!cancelled) {
           console.error('[BlueskyAuth] init failed', err);
           setError(err?.message ?? 'Failed to initialize Bluesky auth');
@@ -305,6 +321,35 @@ export function BlueskyAuthProvider({
     [client],
   );
 
+  const signInPopup = useCallback(
+    async (handleInput: string) => {
+      if (!client) throw new Error('Bluesky auth not ready');
+      const clean = handleInput.trim().replace(/^@/, '');
+      if (!clean) throw new Error('Enter a Bluesky handle');
+      // No awaits before this call — signInPopup opens its window
+      // synchronously and must still be inside the click gesture or
+      // popup blockers eat it. Resolves (via BroadcastChannel from the
+      // callback page) once the user finishes on the PDS; THIS page
+      // never navigates.
+      const s = await client.signInPopup(clean, {
+        scope: ATPROTO_PUBLISH_OAUTH_SCOPE,
+      });
+      // Same session-application as the init() restore path.
+      setSession(s);
+      setDid(s.did);
+      const { Agent } = await import('@atproto/api');
+      const a = new Agent(s as any);
+      setAgent(a);
+      try {
+        const profile = await a.com.atproto.repo.describeRepo({ repo: s.did });
+        setHandle((profile?.data as any)?.handle || s.did);
+      } catch {
+        setHandle(s.did);
+      }
+    },
+    [client],
+  );
+
   const signOut = useCallback(async () => {
     if (!client || !did) return;
     try {
@@ -326,10 +371,11 @@ export function BlueskyAuthProvider({
       handle,
       agent,
       signIn,
+      signInPopup,
       signOut,
       error,
     }),
-    [isReady, session, did, handle, agent, signIn, signOut, error],
+    [isReady, session, did, handle, agent, signIn, signInPopup, signOut, error],
   );
 
   return <BlueskyAuthContext.Provider value={value}>{children}</BlueskyAuthContext.Provider>;

--- a/packages/shared/src/contexts/BlueskyAuth.tsx
+++ b/packages/shared/src/contexts/BlueskyAuth.tsx
@@ -85,8 +85,11 @@ const BlueskyAuthContext = createContext<BlueskyAuthState>(DEFAULT_STATE);
  *  staging. Defaults to pantryhost.app. */
 function getProdClientId(): string {
   try {
+    // Exact `import.meta.env.VITE_X` token required — Vite's env
+    // replacement doesn't recognize optional-chained access; the
+    // try/catch covers non-Vite bundlers.
     // @ts-expect-error Vite-ism
-    const fromVite = import.meta?.env?.VITE_ATPROTO_CLIENT_ID;
+    const fromVite = import.meta.env.VITE_ATPROTO_CLIENT_ID;
     if (fromVite) return String(fromVite);
   } catch {
     /* not vite */

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -28,6 +28,7 @@ import RecipeApiImportPage from './pages/RecipeApiImportPage';
 import CooklangImportPage from './pages/CooklangImportPage';
 import WikibooksImportPage from './pages/WikibooksImportPage';
 import BlueskyCallbackPage from './pages/BlueskyCallbackPage';
+import PublishBrokerPage from './pages/PublishBrokerPage';
 import { BlueskyAuthProvider } from '@pantry-host/shared/contexts/BlueskyAuth';
 
 /**
@@ -71,6 +72,10 @@ export default function App() {
       <BlueskyAuthProvider callbackPath="/oauth/bluesky/callback">
         <Routes>
           <Route path="/oauth/bluesky/callback" element={<BlueskyCallbackPage />} />
+          {/* Popup target for self-hosted instances that can't do AT
+              OAuth on their own origin — no Layout chrome (see
+              PublishBrokerPage + shared/atproto-broker). */}
+          <Route path="/publish-broker" element={<PublishBrokerPage />} />
           <Route element={<Layout />}>
             <Route path="/" element={<HomePage />} />
             {/* Top-level = home kitchen */}

--- a/packages/web/src/globals.css
+++ b/packages/web/src/globals.css
@@ -810,6 +810,15 @@
     font-family: Menlo, Consolas, Monaco, Adwaita Mono, Liberation Mono, Lucida Console, monospace;
   }
 
+  /* Background body — mirror of the app's hand-rolled utilities; the
+     shared Modal (and friends) depend on these. Keep in sync with
+     packages/app/styles/globals.css. */
+  .bg-body {
+    background-color: var(--color-bg-body);
+  }
+  .bg-body-translucent {
+    background-color: color-mix(in srgb, var(--color-bg-body) 90%, transparent);
+  }
   .text-secondary {
     color: var(--color-text-secondary);
   }

--- a/packages/web/src/pages/PublishBrokerPage.tsx
+++ b/packages/web/src/pages/PublishBrokerPage.tsx
@@ -59,9 +59,11 @@ export default function PublishBrokerPage() {
     document.title = 'Publish to Bluesky — Pantry Host';
   }, []);
 
-  // Handshake: announce readiness to the opener (repeats naturally
-  // after an OAuth redirect lands us back here), accept the FIRST
-  // request, ignore everything after.
+  // Handshake: announce readiness to the opener, accept the FIRST
+  // request, ignore everything after. NOTE: this page must never
+  // navigate — the PDS auth pages send COOP headers that would sever
+  // window.opener for good, orphaning us from the requester. That's
+  // why sign-in below uses the popup flow, not the redirect flow.
   useEffect(() => {
     function onMessage(event: MessageEvent) {
       if (acceptedRef.current) return;
@@ -245,7 +247,9 @@ export default function PublishBrokerPage() {
         <p className="text-sm text-[var(--color-danger)] pretty">{phase.message} — you can close this window and try again.</p>
       )}
 
-      <BlueskySignInModal open={signInOpen} onClose={() => setSignInOpen(false)} />
+      {/* mode="popup": OAuth in a nested popup so THIS page never
+          navigates (see handshake note above). */}
+      <BlueskySignInModal mode="popup" open={signInOpen} onClose={() => setSignInOpen(false)} />
     </main>
   );
 }

--- a/packages/web/src/pages/PublishBrokerPage.tsx
+++ b/packages/web/src/pages/PublishBrokerPage.tsx
@@ -1,0 +1,263 @@
+/**
+ * /publish-broker — the trusted-origin side of the publish broker
+ * (see @pantry-host/shared/atproto-broker for the protocol and the
+ * security invariants).
+ *
+ * Opened as a POPUP by a self-hosted Pantry Host instance whose origin
+ * can't complete AT OAuth (issue #37). This page runs on the hosted
+ * origin where OAuth works, so the session — and its DPoP keys — never
+ * leave here. The requester sends a record payload in; the user reviews
+ * it HERE (real URL bar, requesting origin displayed, confirm click
+ * inside this window); the write goes browser → PDS; only receipts go
+ * back, targetOrigin-locked to the requester.
+ *
+ * One request per popup lifetime: the first ph-broker:request wins and
+ * later ones are ignored, so the payload can't be swapped after the
+ * confirm UI renders.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Butterfly } from '@phosphor-icons/react';
+import BlueskySignInModal from '@pantry-host/shared/components/BlueskySignInModal';
+import { useBlueskyAuth } from '@pantry-host/shared/contexts/BlueskyAuth';
+import {
+  BROKER_READY,
+  BROKER_REQUEST,
+  BROKER_RESULT,
+  type BrokerReceipt,
+  type BrokerRequest,
+  type BrokerResult,
+} from '@pantry-host/shared/atproto-broker';
+import {
+  buildCollectionRecord,
+  buildRecipeRecord,
+  fetchPhotoBlob,
+  publishCollection,
+  publishRecipe,
+  unpublish,
+  type PublishAgent,
+} from '@pantry-host/shared/atproto-publish';
+
+type Phase =
+  | { name: 'waiting' } // no opener message yet (or opened directly)
+  | { name: 'review'; request: BrokerRequest; requesterOrigin: string }
+  | { name: 'publishing'; request: BrokerRequest; requesterOrigin: string }
+  | { name: 'done'; message: string }
+  | { name: 'error'; message: string };
+
+export default function PublishBrokerPage() {
+  const { isReady, isSignedIn, agent, handle } = useBlueskyAuth();
+  const [phase, setPhase] = useState<Phase>({ name: 'waiting' });
+  const [signInOpen, setSignInOpen] = useState(false);
+  const [announcement, setAnnouncement] = useState('');
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  // The window we reply to, captured from the accepted request event.
+  const requesterRef = useRef<{ source: MessageEventSource; origin: string } | null>(null);
+  const acceptedRef = useRef(false);
+
+  useEffect(() => {
+    document.title = 'Publish to Bluesky — Pantry Host';
+  }, []);
+
+  // Handshake: announce readiness to the opener (repeats naturally
+  // after an OAuth redirect lands us back here), accept the FIRST
+  // request, ignore everything after.
+  useEffect(() => {
+    function onMessage(event: MessageEvent) {
+      if (acceptedRef.current) return;
+      const data = event.data as { type?: string } | null;
+      if (!data || data.type !== BROKER_REQUEST || !event.source) return;
+      acceptedRef.current = true;
+      requesterRef.current = { source: event.source, origin: event.origin };
+      setPhase({ name: 'review', request: data as BrokerRequest, requesterOrigin: event.origin });
+    }
+    window.addEventListener('message', onMessage);
+    // The ready ping carries no data; '*' is fine — we can't know the
+    // opener's origin before it speaks.
+    window.opener?.postMessage({ type: BROKER_READY }, '*');
+    return () => window.removeEventListener('message', onMessage);
+  }, []);
+
+  // Announce + focus when the review step appears.
+  useEffect(() => {
+    if (phase.name === 'review') {
+      headingRef.current?.focus();
+      setAnnouncement(`Publish request received from ${phase.requesterOrigin}. Review and confirm.`);
+    }
+  }, [phase.name === 'review' ? phase.requesterOrigin : null]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function reply(result: BrokerResult) {
+    const req = requesterRef.current;
+    if (req) (req.source as Window).postMessage(result, { targetOrigin: req.origin });
+  }
+
+  function cancel() {
+    reply({ type: BROKER_RESULT, ok: false, error: 'cancelled' });
+    setPhase({ name: 'done', message: 'Cancelled. You can close this window.' });
+    setAnnouncement('Cancelled.');
+  }
+
+  async function confirm() {
+    if (phase.name !== 'review') return;
+    const { request, requesterOrigin } = phase;
+    if (!agent || !handle) {
+      setSignInOpen(true);
+      return;
+    }
+    setPhase({ name: 'publishing', request, requesterOrigin });
+    setAnnouncement('Publishing…');
+    const pubAgent = agent as unknown as PublishAgent;
+    try {
+      if (request.action === 'unpublish') {
+        await unpublish(request.uri, { agent: pubAgent, handle, dryRun: request.dryRun });
+        reply({ type: BROKER_RESULT, ok: true, action: 'unpublish' });
+        setPhase({ name: 'done', message: request.dryRun ? 'Dry run — nothing was deleted.' : 'Record removed from your PDS.' });
+        setAnnouncement('Unpublished.');
+        return;
+      }
+      // photoBlobs were fetched on the requester's origin (its /uploads
+      // are unreachable from here); fall back to a direct fetch for
+      // external URLs the broker origin can reach.
+      const fetchPhoto = (url: string) =>
+        request.photoBlobs?.[url] ? Promise.resolve(request.photoBlobs[url]) : fetchPhotoBlob(url);
+      const opts = { agent: pubAgent, handle, dryRun: request.dryRun, rkey: request.rkey, fetchPhoto };
+
+      if (request.kind === 'recipe') {
+        const res = await publishRecipe(request.recipe, opts);
+        const receipt: BrokerReceipt = { uri: res.uri, cid: res.cid, handle, dryRun: res.dryRun };
+        reply({ type: BROKER_RESULT, ok: true, action: 'publish', kind: 'recipe', receipt });
+      } else {
+        const { collection, recipePublishes } = await publishCollection(
+          request.menu,
+          (recipeId) => request.existingRefs?.[recipeId] ?? null,
+          opts,
+        );
+        const childReceipts: Record<string, BrokerReceipt> = {};
+        for (const p of recipePublishes) {
+          if (p.result) childReceipts[p.recipeId] = { uri: p.result.uri, cid: p.result.cid, handle, dryRun: p.result.dryRun };
+        }
+        const receipt: BrokerReceipt = { uri: collection.uri, cid: collection.cid, handle, dryRun: collection.dryRun };
+        reply({ type: BROKER_RESULT, ok: true, action: 'publish', kind: 'menu', receipt, childReceipts });
+      }
+      setPhase({ name: 'done', message: request.dryRun ? 'Dry run complete — nothing left this device.' : `Published to @${handle}'s PDS.` });
+      setAnnouncement(request.dryRun ? 'Dry run complete.' : `Published to @${handle}'s PDS.`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Publish failed';
+      reply({ type: BROKER_RESULT, ok: false, error: message });
+      setPhase({ name: 'error', message });
+      setAnnouncement(`Publish failed: ${message}`);
+    }
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────
+
+  const recordJson =
+    phase.name === 'review' || phase.name === 'publishing'
+      ? previewJson(phase.request)
+      : null;
+  const req = phase.name === 'review' || phase.name === 'publishing' ? phase.request : null;
+
+  return (
+    <main id="stage" className="min-h-screen bg-[var(--color-bg-body)] text-[var(--color-text-primary)] px-5 py-6 max-w-xl mx-auto">
+      {/* Persistent live region — mounted empty, populated on events,
+          so screen readers actually announce them. */}
+      <div role="status" className="sr-only">{announcement}</div>
+
+      <header className="flex items-center gap-2 mb-4">
+        <Butterfly size={22} weight="light" aria-hidden />
+        <h1 ref={headingRef} tabIndex={-1} className="text-lg font-bold outline-none">
+          {req?.action === 'unpublish' ? 'Remove from Bluesky' : 'Publish to Bluesky'}
+        </h1>
+        {req?.dryRun && (
+          <span className="text-[10px] uppercase tracking-wider px-2 py-1 rounded-md bg-[var(--color-warning-bg)] text-[var(--color-warning)] font-semibold">
+            Dry run
+          </span>
+        )}
+      </header>
+
+      {phase.name === 'waiting' && (
+        <p className="text-sm text-[var(--color-text-secondary)] pretty">
+          {window.opener
+            ? 'Waiting for the publish request from the window that opened this one…'
+            : 'This window is meant to be opened by a Pantry Host instance when you click Share to Bluesky. There is nothing to do here directly.'}
+        </p>
+      )}
+
+      {(phase.name === 'review' || phase.name === 'publishing') && req && (
+        <>
+          {/* Who's asking — the load-bearing line of the whole design. */}
+          <p className="text-sm mb-1 pretty">
+            <strong className="font-mono text-[13px] break-all">{phase.requesterOrigin}</strong>{' '}
+            wants to {req.action === 'unpublish' ? 'remove' : 'publish'}{' '}
+            <strong>{req.action === 'unpublish' ? req.title : req.kind === 'recipe' ? req.recipe.title : req.menu.title}</strong>
+            {req.action === 'publish' ? <> {req.kind === 'menu' ? 'and its recipes ' : ''}to your PDS</> : ' from your PDS'}.
+          </p>
+          <p className="text-xs text-[var(--color-text-secondary)] mb-4 pretty">
+            {isSignedIn ? (
+              <>Signed in as <strong>@{handle}</strong>. Nothing happens until you confirm below.</>
+            ) : (
+              <>Sign in with Bluesky to continue. Nothing happens until you confirm.</>
+            )}
+          </p>
+
+          {req.action === 'publish' && req.kind === 'menu' && (
+            <ul className="text-sm mb-3 space-y-1">
+              {req.menu.recipes.map((r) => (
+                <li key={r.id} className="flex items-center gap-2">
+                  <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--color-bg-card)] border border-[var(--color-border-card)] shrink-0">
+                    {req.existingRefs?.[r.id] ? 'Reuse' : 'Publish'}
+                  </span>
+                  <span className="truncate">{r.title}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {recordJson && (
+            <pre className="text-[11px] font-mono leading-relaxed bg-[var(--color-bg-card)] border border-[var(--color-border-card)] rounded-lg p-3 overflow-auto max-h-72 whitespace-pre mb-4">
+              {recordJson}
+            </pre>
+          )}
+
+          <div className="flex items-center justify-end gap-2">
+            <button type="button" onClick={cancel} className="btn-secondary" disabled={phase.name === 'publishing'}>
+              Cancel
+            </button>
+            {isReady && !isSignedIn ? (
+              <button type="button" onClick={() => setSignInOpen(true)} className="btn-primary">
+                Sign in with Bluesky
+              </button>
+            ) : (
+              <button type="button" onClick={confirm} className="btn-primary" disabled={!isReady || phase.name === 'publishing'}>
+                {phase.name === 'publishing'
+                  ? 'Publishing…'
+                  : req.action === 'unpublish'
+                    ? req.dryRun ? 'Remove (dry run)' : 'Remove'
+                    : req.dryRun ? 'Publish (dry run)' : 'Publish'}
+              </button>
+            )}
+          </div>
+        </>
+      )}
+
+      {phase.name === 'done' && <p className="text-sm pretty">{phase.message} You can close this window.</p>}
+      {phase.name === 'error' && (
+        <p className="text-sm text-[var(--color-danger)] pretty">{phase.message} — you can close this window and try again.</p>
+      )}
+
+      <BlueskySignInModal open={signInOpen} onClose={() => setSignInOpen(false)} />
+    </main>
+  );
+}
+
+/** The exact record JSON that will be written — same honesty rule as
+ *  the in-app preview modal. Menus preview with placeholder refs;
+ *  real strongRefs are resolved at publish time. */
+function previewJson(request: BrokerRequest): string | null {
+  if (request.action === 'unpublish') return null;
+  if (request.kind === 'recipe') {
+    return JSON.stringify(buildRecipeRecord(request.recipe), null, 2);
+  }
+  const placeholderRefs = request.menu.recipes.map((r) => request.existingRefs?.[r.id] ?? { uri: '(to be minted on publish)', cid: '(tbd)' });
+  return JSON.stringify(buildCollectionRecord(request.menu, placeholderRefs), null, 2);
+}


### PR DESCRIPTION
Implements track C of #37. Self-hosted origins (LAN IP, Tailscale, plain HTTP) can't complete AT OAuth — the `client_id` must be a publicly-fetchable HTTPS document and web-client redirect URIs must live on its origin. Instead of moving the *session* to the self-hosted origin (token hand-off defeats DPoP; server-side relay makes us a credential custodian, which SOVEREIGNTY.md forbids), this moves the *publish request* to the session:

```
self-hosted page ──window.open──▶ my.pantryhost.app/publish-broker
     │◀───── ph-broker:ready ─────│   (replays across OAuth redirects)
     │────── ph-broker:request ──▶│   (record + photo Blobs, structured clone)
     │                            │   user reviews + CONFIRMS in the popup
     │                            │──▶ PDS  (browser-side putRecord)
     │◀───── ph-broker:result ────│   (receipts, targetOrigin-locked)
```

## Security invariants (encoded in `shared/atproto-broker.ts` doc comments)
- **Tokens and DPoP keys never leave the broker origin.** Only record payloads go in; only receipts come out.
- **One request per popup lifetime** — the first `ph-broker:request` wins; later messages are ignored, so the payload can't be swapped after the confirm UI renders. *(verified)*
- **The confirm click happens inside the popup** — a real window with a real URL bar (no clickjacking), with the requesting origin displayed prominently.
- **Replies use an explicit `targetOrigin`** (the captured requester origin), never `'*'`. The ready ping carries no data.
- **No write without a user gesture** in the trusted origin.

Records still travel **browser → PDS**; Pantry Host infrastructure stores nothing. The honest trade-off: self-hosted publishing gains an availability/trust dependency on the hosted origin — the fully-sovereign paths (own public domain, app passwords) remain #37 tracks A/B.

## What's in it
- **`shared/atproto-broker.ts`** — protocol + `publishViaBroker()` (popup opens synchronously on the click tick; the payload may be a `Promise` so photo-Blob collection finishes while the popup loads; the ready→request handshake replays if the popup bounces through OAuth sign-in), `shouldUseBroker()` origin detection, `collectPhotoBlobs()` (photos fetched on the requester origin, where `/uploads` is same-origin — incidentally sidesteps the external-photo CORS gap for broker publishes when the requester can reach the image).
- **web `/publish-broker`** — review UI: origin callout, exact record JSON (same honesty rule as the preview modal), Reuse/Publish child plan for menus, dry-run badge, sign-in via the existing OAuth modal, publish + unpublish, persistent sr-only live region + heading focus (WCAG 4.1.3).
- **`PublishToBlueskyButton`** — on broker origins, Share/Re-publish/Unpublish open the popup instead of local modals; returned receipts (including per-child receipts for menu publishes) feed the existing receipt store so the CTA flips and future menus Reuse; the #36 stale-receipt reconcile now also runs without a local session (`recordExists` is a public read). Deterministic rkeys (#36) make broker re-publishes idempotent.

## Verified
- Browser-driven protocol test: direct-load explainer, request accepted (origin + title + dry badge + record JSON rendered), **payload-swap ignored**, cancel replies `{ok:false,error:'cancelled'}`, live region announces, focus lands on the heading
- Both tiers typecheck at baseline (web 50 / app 119); web `vite build` passes

## Needs a human before merge
- A **real signed-in publish through the popup** (OAuth session can't be driven headlessly). Suggested test once this deploys to my.pantryhost.app: open the Mini over Tailscale, Share to Bluesky → popup → confirm → check the record and that the Mini's CTA flips to "View on Bluesky".
- iOS Safari popup behavior is the usual wildcard — the popup opens synchronously on the click, but worth a phone test.

Closes the practical gap in #37 for most self-hosters; tracks A (own-domain OAuth) and B (app passwords) stay open there for full sovereignty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)