### PR TITLE
fix: stale localStorage cache seeds must not crash detail pages

### DIFF
--- a/packages/app/components/pages/MenuDetailPage.tsx
+++ b/packages/app/components/pages/MenuDetailPage.tsx
@@ -89,10 +89,23 @@ interface Props {
   initialMenu?: Menu | null;
 }
 
+/** Same stale-cache-seed defense as RecipeDetailPage: an entry written
+ *  by an older code era can lack the arrays this render iterates
+ *  (menu.recipes, each recipe's tags), and a crash during the seed
+ *  render is permanent — it also blocks the fetch that would repair
+ *  the cache. Rejected seeds just mean skeleton UI until the fetch. */
+function isRenderableMenuShape(m: Menu): boolean {
+  return (
+    Array.isArray(m.recipes) &&
+    m.recipes.every((mr) => mr && mr.recipe && Array.isArray(mr.recipe.tags) && Array.isArray(mr.recipe.groceryIngredients))
+  );
+}
+
 export default function MenuDetailPage({ menuId, initialMenu }: Props) {
   const kitchen = useKitchen();
   const cacheKey = `cache:menu:${menuId}`;
-  const cachedMenu = isBrowser ? cacheGet<Menu>(cacheKey) : null;
+  const rawCachedMenu = isBrowser ? cacheGet<Menu>(cacheKey) : null;
+  const cachedMenu = rawCachedMenu && isRenderableMenuShape(rawCachedMenu) ? rawCachedMenu : null;
   const [menu, setMenu] = useState<Menu | null>(initialMenu ?? cachedMenu);
   const [notFound, setNotFound] = useState(false);
   const [owner, setOwner] = useState(false);

--- a/packages/app/components/pages/RecipeDetailPage.tsx
+++ b/packages/app/components/pages/RecipeDetailPage.tsx
@@ -209,13 +209,34 @@ function StepPhotos({ steps, sourceUrl, dbStepPhotos }: { steps: string[]; sourc
   );
 }
 
+/** Cache seeds outlive deploys: an entry written by an older code era
+ *  can be missing arrays this page's render iterates, and a crash
+ *  during the seed render is a PERMANENT white screen — the crash also
+ *  prevents the fetch that would repair the cache (seen in prod:
+ *  'e.ingredients is not iterable' loop on a stale seed). Only trust a
+ *  seed whose load-bearing arrays are actually arrays; a rejected seed
+ *  just means skeleton UI until the fetch repopulates. */
+function isRenderableRecipeShape(r: Recipe): boolean {
+  return (
+    Array.isArray(r.ingredients) &&
+    Array.isArray(r.groceryIngredients) &&
+    Array.isArray(r.tags) &&
+    Array.isArray(r.requiredCookware) &&
+    Array.isArray(r.stepPhotos) &&
+    Array.isArray(r.usedIn)
+  );
+}
+
 export default function RecipeDetailPage({ recipeId, initialRecipe }: Props) {
   const kitchen = useKitchen();
   const router = useRouter();
   const recipesBase = `/kitchens/${kitchen}/recipes`;
 
   const cacheKey = `cache:recipe:${recipeId}`;
-  const cachedRecipe = isBrowser ? cacheGet<Recipe>(cacheKey) : null;
+  // (initialRecipe comes from this build's own GSSP, so it's always
+  // shape-current — only the localStorage seed needs vetting.)
+  const rawCached = isBrowser ? cacheGet<Recipe>(cacheKey) : null;
+  const cachedRecipe = rawCached && isRenderableRecipeShape(rawCached) ? rawCached : null;
   const seedRecipe = initialRecipe ?? cachedRecipe;
   const [recipe, setRecipe] = useState<Recipe | null>(seedRecipe);
   const [notFound, setNotFound] = useState(false);

--- a/packages/shared/src/nutrition-aggregate.ts
+++ b/packages/shared/src/nutrition-aggregate.ts
@@ -202,7 +202,13 @@ export function aggregateNutrition(input: AggregateInput): AggregateResult {
   const contributors: Contributor[] = [];
   const missing: MissingIngredient[] = [];
 
-  for (const ing of input.ingredients) {
+  // `?? []`: callers can be fed recipe objects from untrusted shapes —
+  // e.g. a localStorage cache entry written by an older code era that
+  // lacked `ingredients`. A missing list must degrade to "no nutrition
+  // data", never crash the page render (seen in prod: stale cache seed
+  // → 'ingredients is not iterable' → permanent white-screen loop,
+  // because the crash also prevents the fetch that would repair it).
+  for (const ing of input.ingredients ?? []) {
     const pantry = findPantryItem(input.lookup, ing.ingredientName);
     if (!pantry) {
       missing.push({ name: ing.ingredientName, reason: 'no-match', qty: ing.quantity, unit: ing.unit });
@@ -260,7 +266,7 @@ export function aggregateAllergens(input: {
     if (substance) seen.add(substance);
   }
   // Metadata-based: derived from scanned barcode data.
-  for (const ing of input.ingredients) {
+  for (const ing of input.ingredients ?? []) {
     const pantry = findPantryItem(input.lookup, ing.ingredientName);
     const meta = safeParseMeta(pantry?.productMeta);
     if (!meta?.allergens_tags) continue;


### PR DESCRIPTION
## The bug

`Uncaught TypeError: e.ingredients is not iterable` as a **permanent white screen** on a recipe detail page. The `cache:recipe:{slug}` localStorage seed had been written by an older code era and lacked `ingredients`; `aggregateNutrition` iterates it unguarded; and because the crash happens during the seed render — *before* the GraphQL fetch — the bad entry never gets repaired. A crash loop escapable only by hand-deleting the key. Service-worker/Cache-API clears don't touch localStorage, which made it masquerade as unfixable staleness.

## The fix (two layers)

1. **`aggregateNutrition`** (shared → both tiers): `for (const ing of input.ingredients ?? [])` at both iteration sites — a missing list degrades to "no nutrition data," never a crashed render.
2. **Recipe + Menu detail pages** (app): validate the cache seed's load-bearing arrays (`ingredients`, `groceryIngredients`, `tags`, `requiredCookware`, `stepPhotos`, `usedIn`; `menu.recipes` + per-child shapes) before trusting it. A rejected seed = skeleton UI until the fetch repopulates — and the fresh `cacheSet` **repairs** the stored entry. SSR `initialRecipe` needs no vetting: it's produced by this build's own GSSP.

## Verified

Reproduced against the Rex prod build by deleting `ingredients` from the cached seed:
- **Before:** reload → `bodyChars: 0`, permanent white screen, cache never repaired.
- **After:** reload → full page render (`h1` present, 3.6 KB content) **and** the cache entry re-written with the correct shape by the post-render fetch.
- Both tiers typecheck at baseline (app 119 / web 50).

Worth merging ahead of broader testing — any pre-existing install with old cache entries can hit this on upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)