### PR TITLE
Adopt-own-records: re-publishing your own import updates the original

### DIFF
--- a/packages/app/components/pages/MenuDetailPage.tsx
+++ b/packages/app/components/pages/MenuDetailPage.tsx
@@ -439,6 +439,7 @@ export default function MenuDetailPage({ menuId, initialMenu }: Props) {
               id: menu.id,
               title: menu.title,
               description: menu.description,
+              sourceUrl: menu.sourceUrl,
               createdAt: menu.createdAt,
               recipes: menu.recipes.map((mr) => ({
                 id: mr.recipe.id,

--- a/packages/shared/src/atproto-broker.ts
+++ b/packages/shared/src/atproto-broker.ts
@@ -62,6 +62,12 @@ export type BrokerRequest =
       /** Re-publish target for records that predate deterministic
        *  rkeys — omit to publish at rkeyForLocal(recipe.id). */
       rkey?: string;
+      /** The recipe's at:// sourceUrl, when it has one. The requester
+       *  can't know whose record it is (it has no session); the BROKER
+       *  decides after sign-in: if the signed-in DID owns it, publish
+       *  at its rkey (adopt-own-records — updates the original instead
+       *  of minting a duplicate). Ignored otherwise. */
+      adoptUri?: string;
       /** photoUrl → bytes, fetched by the requester (same-origin
        *  there; the broker origin can't reach a LAN box). */
       photoBlobs?: Record<string, Blob>;
@@ -73,6 +79,8 @@ export type BrokerRequest =
       kind: 'menu';
       menu: PublishableMenu;
       rkey?: string;
+      /** See the recipe variant — the menu's at:// sourceUrl. */
+      adoptUri?: string;
       /** recipeId → known-good strongRef, so already-published
        *  children are reused instead of re-published. */
       existingRefs?: Record<string, { uri: string; cid: string }>;

--- a/packages/shared/src/atproto-publish.ts
+++ b/packages/shared/src/atproto-publish.ts
@@ -77,6 +77,11 @@ export interface PublishableMenu {
   id: string;
   title: string;
   description?: string | null;
+  /** Where this menu came from. An `at://` URI here (Bluesky import)
+   *  enables adopt-own-records: re-publishing an imported copy of
+   *  YOUR OWN collection updates the original instead of minting a
+   *  duplicate. */
+  sourceUrl?: string | null;
   createdAt?: string | null;
   recipes: PublishableRecipe[];
 }
@@ -459,15 +464,35 @@ export async function publishRecipe(
     return { uri, cid, dryRun: true, record };
   }
 
-  const embed = await buildPhotoEmbed(recipe, opts);
-  if (embed) record.embed = embed;
-
   // Deterministic rkey (from the local id) unless an explicit rkey is
   // given. putRecord creates-or-overwrites, so first publish and every
   // re-publish hit one record — no duplicate on a second device or a
   // cleared cache. `opts.rkey` still wins for records published before
-  // this change (their original rkey rides in on the localStorage receipt).
+  // this change (their original rkey rides in on the localStorage
+  // receipt) and for adopt-own-records (the sourceUrl's rkey).
   const rkey = opts.rkey ?? rkeyForLocal(recipe.id);
+
+  // Publishing over the record the sourceUrl points at (adopt-own-
+  // records) — attribution to yourself is noise, drop it.
+  if (record.attribution?.originalUri === `at://${opts.agent.did}/${LEXICON_RECIPE}/${rkey}`) {
+    delete record.attribution;
+  }
+
+  let embed = await buildPhotoEmbed(recipe, opts);
+  if (!embed) {
+    // Photo unavailable from here (CORS-blocked CDN, opfs on another
+    // device…) — if the target record already exists with a photo,
+    // carry its embed forward. The blob lives in this same repo, so
+    // reusing the ref is valid and re-publish never *loses* a photo.
+    try {
+      const existing = await getRecord<BlueskyRecipeRecord>(opts.agent.did, LEXICON_RECIPE, rkey);
+      if (existing.value?.embed) embed = existing.value.embed;
+    } catch {
+      /* nothing published there yet */
+    }
+  }
+  if (embed) record.embed = embed;
+
   const res = await opts.agent.com.atproto.repo.putRecord({
     repo: opts.agent.did,
     collection: LEXICON_RECIPE,
@@ -500,10 +525,19 @@ export async function publishCollection(
       recipePublishes.push({ recipeId: r.id, result: null, ref: existing });
       continue;
     }
+    // Adopt-own-records: an imported copy of the user's OWN recipe
+    // re-publishes at the original's rkey — local edits land on the
+    // original record instead of a strongRef freezing them out.
+    const adoptRkey = adoptRkeyFromSource(r.sourceUrl, LEXICON_RECIPE, opts.agent.did);
+    if (adoptRkey) {
+      const res = await publishRecipe(r, { ...opts, rkey: adoptRkey });
+      recipePublishes.push({ recipeId: r.id, result: res, ref: { uri: res.uri, cid: res.cid } });
+      continue;
+    }
     if (r.sourceUrl?.startsWith('at://')) {
-      // Upstream Bluesky recipe — reuse as strongRef if we can read
-      // its CID. In dry-run we mint a synthetic ref so we don't fire
-      // a network read either.
+      // Upstream Bluesky recipe (someone else's) — reuse as strongRef
+      // if we can read its CID. In dry-run we mint a synthetic ref so
+      // we don't fire a network read either.
       if (dry) {
         const { uri, cid } = mintDryRunRef(opts.agent.did, LEXICON_RECIPE);
         recipePublishes.push({ recipeId: r.id, result: null, ref: { uri: r.sourceUrl, cid } });
@@ -579,6 +613,45 @@ export async function unpublish(atUri: string, opts: PublishOptions): Promise<{ 
 export function rkeyFromUri(atUri: string): string | null {
   const parts = atUri.replace(/^at:\/\//, '').split('/');
   return parts.length === 3 ? parts[2] : null;
+}
+
+/** Split an `at://did/collection/rkey` URI into its parts, or null
+ *  for anything else (https URLs, malformed URIs, null). */
+export function parseAtUri(
+  atUri: string | null | undefined,
+): { did: string; collection: string; rkey: string } | null {
+  if (!atUri || !atUri.startsWith('at://')) return null;
+  const parts = atUri.slice('at://'.length).split('/');
+  if (parts.length !== 3 || parts.some((p) => !p)) return null;
+  return { did: parts[0], collection: parts[1], rkey: parts[2] };
+}
+
+/** Adopt-own-records: if this item's sourceUrl points at a record of
+ *  `collection` OWNED by `did` (the signed-in account), return its
+ *  rkey — publishing there updates the original in place instead of
+ *  minting a duplicate. Anyone else's record (or a non-AT source)
+ *  returns null and the normal deterministic-rkey path applies. */
+export function adoptRkeyFromSource(
+  sourceUrl: string | null | undefined,
+  collection: string,
+  did: string,
+): string | null {
+  const parsed = parseAtUri(sourceUrl);
+  return parsed && parsed.did === did && parsed.collection === collection ? parsed.rkey : null;
+}
+
+/** Live `{ uri, cid }` for an AT URI, or null if it doesn't resolve.
+ *  Public read (no auth) — used to adopt a sourceUrl-referenced
+ *  record as a publish receipt. */
+export async function getRecordInfo(atUri: string): Promise<{ uri: string; cid: string } | null> {
+  const parsed = parseAtUri(atUri);
+  if (!parsed) return null;
+  try {
+    const rec = await getRecord<unknown>(parsed.did, parsed.collection, parsed.rkey);
+    return { uri: rec.uri, cid: rec.cid };
+  } catch {
+    return null;
+  }
 }
 
 /** Deterministic record key derived from a local recipe/menu id.

--- a/packages/shared/src/components/PublishToBlueskyButton.tsx
+++ b/packages/shared/src/components/PublishToBlueskyButton.tsx
@@ -26,10 +26,13 @@ import PublishPreviewModal, {
 } from './PublishPreviewModal';
 import { useBlueskyAuth } from '../contexts/BlueskyAuth';
 import {
+  adoptRkeyFromSource,
   buildCollectionRecord,
   buildRecipeRecord,
   findPublishedRecord,
+  getRecordInfo,
   isDryRun,
+  parseAtUri,
   LEXICON_COLLECTION,
   LEXICON_RECIPE,
   publishCollection,
@@ -95,6 +98,10 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
   const [publishResult, setPublishResult] = useState<PublishSuccessInfo | null>(null);
 
   const id = props.kind === 'recipe' ? props.recipe.id : props.menu.id;
+  // The item's provenance — an at:// URI here may be the user's OWN
+  // published record (imported copy), which publish should update in
+  // place rather than duplicate (adopt-own-records).
+  const sourceAtUri = props.kind === 'recipe' ? props.recipe.sourceUrl : props.menu.sourceUrl;
   const [receipt, setReceipt] = useState<PublishReceipt | null>(() =>
     getPublishReceipt(props.kind, id),
   );
@@ -159,7 +166,16 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
         return;
       }
       if (!local) {
-        const found = await findPublishedRecord(did, collection, id);
+        // Adopt-own-records first: an imported copy of the user's OWN
+        // record (sourceUrl = at:// URI this DID owns) is already
+        // published — reconnect to the ORIGINAL so the CTA shows
+        // "View on Bluesky" and a publish updates it in place.
+        const adoptRkey = adoptRkeyFromSource(sourceAtUri, collection, did);
+        const found =
+          (adoptRkey ? await getRecordInfo(`at://${did}/${collection}/${adoptRkey}`) : null) ??
+          // Original gone (or no at:// source) — the deterministic
+          // rkey may still hold a record published from this device.
+          (await findPublishedRecord(did, collection, id));
         if (cancelled || !found) return;
         const adopted: PublishReceipt = {
           uri: found.uri,
@@ -251,13 +267,20 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
     setPending(true);
     try {
       const pubAgent = agent as unknown as PublishAgent;
+      // rkey precedence: a usable receipt (dry ones never leak into a
+      // real putRecord), then adopt-own-records (sourceUrl points at a
+      // record this DID owns — usually the reconcile effect has already
+      // turned that into a receipt; this covers the race before it
+      // lands), then the deterministic default inside publishRecipe.
+      const rkeyFor = (collection: string) =>
+        (usableReceipt(receipt) ? rkeyFromUri(receipt.uri) ?? undefined : undefined) ??
+        adoptRkeyFromSource(sourceAtUri, collection, pubAgent.did) ??
+        undefined;
       if (props.kind === 'recipe') {
         const res = await publishRecipe(props.recipe, {
           agent: pubAgent,
           handle,
-          // A dry receipt's DRYRUN- rkey must not leak into a real
-          // putRecord — fall through to createRecord instead.
-          rkey: usableReceipt(receipt) ? rkeyFromUri(receipt.uri) ?? undefined : undefined,
+          rkey: rkeyFor(LEXICON_RECIPE),
           fetchPhoto: props.fetchPhoto,
         });
         const newReceipt: PublishReceipt = {
@@ -281,7 +304,7 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
           {
             agent: pubAgent,
             handle,
-            rkey: usableReceipt(receipt) ? rkeyFromUri(receipt.uri) ?? undefined : undefined,
+            rkey: rkeyFor(LEXICON_COLLECTION),
             fetchPhoto: props.fetchPhoto,
           },
         );
@@ -408,9 +431,14 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
     // popup loads and is delivered on its ready ping.
     const request = (async (): Promise<BrokerRequest> => {
       const rkey = usableReceipt(receipt) ? rkeyFromUri(receipt.uri) ?? undefined : undefined;
+      // Adopt-own-records: we can't judge ownership here (no session
+      // on this origin) — send the at:// source along and let the
+      // broker decide against the signed-in DID.
+      const expected = props.kind === 'recipe' ? LEXICON_RECIPE : LEXICON_COLLECTION;
+      const adoptUri = parseAtUri(sourceAtUri)?.collection === expected ? sourceAtUri ?? undefined : undefined;
       if (props.kind === 'recipe') {
         const photoBlobs = await collectPhotoBlobs([props.recipe.photoUrl], props.fetchPhoto);
-        return { type: BROKER_REQUEST, action: 'publish', kind: 'recipe', recipe: props.recipe, rkey, photoBlobs, dryRun: dry };
+        return { type: BROKER_REQUEST, action: 'publish', kind: 'recipe', recipe: props.recipe, rkey, adoptUri, photoBlobs, dryRun: dry };
       }
       const existingRefs: Record<string, { uri: string; cid: string }> = {};
       for (const r of props.menu.recipes) {
@@ -418,7 +446,7 @@ export default function PublishToBlueskyButton(props: PublishToBlueskyButtonProp
         if (usableReceipt(cr)) existingRefs[r.id] = { uri: cr.uri, cid: cr.cid };
       }
       const photoBlobs = await collectPhotoBlobs(props.menu.recipes.map((r) => r.photoUrl), props.fetchPhoto);
-      return { type: BROKER_REQUEST, action: 'publish', kind: 'menu', menu: props.menu, rkey, existingRefs, photoBlobs, dryRun: dry };
+      return { type: BROKER_REQUEST, action: 'publish', kind: 'menu', menu: props.menu, rkey, adoptUri, existingRefs, photoBlobs, dryRun: dry };
     })();
     setPending(true);
     publishViaBroker(request).then((res) => {

--- a/packages/web/src/pages/MenuDetailPage.tsx
+++ b/packages/web/src/pages/MenuDetailPage.tsx
@@ -309,6 +309,7 @@ export default function MenuDetailPage() {
             id: menu.id,
             title: menu.title,
             description: menu.description,
+            sourceUrl: menu.sourceUrl,
             createdAt: menu.createdAt,
             recipes: menu.recipes.map((mr) => ({
               id: mr.recipe.id,

--- a/packages/web/src/pages/PublishBrokerPage.tsx
+++ b/packages/web/src/pages/PublishBrokerPage.tsx
@@ -29,9 +29,12 @@ import {
   type BrokerResult,
 } from '@pantry-host/shared/atproto-broker';
 import {
+  adoptRkeyFromSource,
   buildCollectionRecord,
   buildRecipeRecord,
   fetchPhotoBlob,
+  LEXICON_COLLECTION,
+  LEXICON_RECIPE,
   publishCollection,
   publishRecipe,
   unpublish,
@@ -46,7 +49,7 @@ type Phase =
   | { name: 'error'; message: string };
 
 export default function PublishBrokerPage() {
-  const { isReady, isSignedIn, agent, handle } = useBlueskyAuth();
+  const { isReady, isSignedIn, agent, handle, did } = useBlueskyAuth();
   const [phase, setPhase] = useState<Phase>({ name: 'waiting' });
   const [signInOpen, setSignInOpen] = useState(false);
   const [announcement, setAnnouncement] = useState('');
@@ -122,7 +125,16 @@ export default function PublishBrokerPage() {
       // external URLs the broker origin can reach.
       const fetchPhoto = (url: string) =>
         request.photoBlobs?.[url] ? Promise.resolve(request.photoBlobs[url]) : fetchPhotoBlob(url);
-      const opts = { agent: pubAgent, handle, dryRun: request.dryRun, rkey: request.rkey, fetchPhoto };
+      // Adopt-own-records: the requester sends its sourceUrl blind
+      // (it has no session); ownership is decided HERE, against the
+      // signed-in DID. An explicit rkey (pre-deterministic receipt)
+      // still wins.
+      const adoptRkey = adoptRkeyFromSource(
+        request.adoptUri,
+        request.kind === 'recipe' ? LEXICON_RECIPE : LEXICON_COLLECTION,
+        pubAgent.did,
+      );
+      const opts = { agent: pubAgent, handle, dryRun: request.dryRun, rkey: request.rkey ?? adoptRkey ?? undefined, fetchPhoto };
 
       if (request.kind === 'recipe') {
         const res = await publishRecipe(request.recipe, opts);
@@ -194,13 +206,33 @@ export default function PublishBrokerPage() {
             <strong>{req.action === 'unpublish' ? req.title : req.kind === 'recipe' ? req.recipe.title : req.menu.title}</strong>
             {req.action === 'publish' ? <> {req.kind === 'menu' ? 'and its recipes ' : ''}to your PDS</> : ' from your PDS'}.
           </p>
-          <p className="text-xs text-[var(--color-text-secondary)] mb-4 pretty">
+          <p className="text-xs text-[var(--color-text-secondary)] mb-1 pretty">
             {isSignedIn ? (
               <>Signed in as <strong>@{handle}</strong>. Nothing happens until you confirm below.</>
             ) : (
               <>Sign in with Bluesky to continue. Nothing happens until you confirm.</>
             )}
           </p>
+          {/* Update-vs-create honesty line — ownership of adoptUri can
+              only be judged once a session names the DID. */}
+          {isSignedIn && did && req.action === 'publish' && (
+            <p className="text-xs text-[var(--color-text-secondary)] mb-4 pretty">
+              {(() => {
+                const updateRkey =
+                  req.rkey ??
+                  adoptRkeyFromSource(req.adoptUri, req.kind === 'recipe' ? LEXICON_RECIPE : LEXICON_COLLECTION, did);
+                return updateRkey ? (
+                  <>
+                    Updates your existing record{' '}
+                    <code className="font-mono text-[11px] break-all">{updateRkey}</code> in place.
+                  </>
+                ) : (
+                  <>Publishes as a new record.</>
+                );
+              })()}
+            </p>
+          )}
+          {!(isSignedIn && did && req.action === 'publish') && <div className="mb-3" />}
 
           {req.action === 'publish' && req.kind === 'menu' && (
             <ul className="text-sm mb-3 space-y-1">


### PR DESCRIPTION
## What

Stacked on #38. When a recipe or menu's `sourceUrl` is an `at://` record **owned by the signed-in DID** (i.e. you imported your own published record), publishing now updates that original in place instead of minting a duplicate at a new deterministic rkey.

Found during the #38 rehearsal: importing Acorn Crusted Salmon from the feed and re-publishing created a second record, because the imported copy's fresh local UUID drove the rkey and nothing consulted the `sourceUrl` pointing back at the original.

## How

- **Ownership check** (`adoptRkeyFromSource`): sourceUrl parses to `at://did/collection/rkey`, DID must equal the signed-in DID, collection must match. Anyone else's record follows the existing paths (new record / strongRef reuse).
- **Direct mode**: the reconcile effect adopts the original on sign-in — an imported copy of your own record shows "View on Bluesky" immediately, and publish flows through the existing receipt→rkey plumbing. A fallback in the publish handler covers the pre-reconcile race.
- **Broker mode**: the requester has no session so it can't judge ownership — it sends `adoptUri` and the **broker** decides against the signed-in DID (trust decision stays on the trusted origin). The review UI is explicit: *"Updates your existing record `<rkey>` in place"* vs *"Publishes as a new record"*.
- **Menu children**: a collection's child recipe with an owned `at://` source re-publishes at the original's rkey (local edits land on the original) instead of being frozen as a strongRef to stale content.
- **Self-attribution**: dropped when publishing over the very record `attribution.originalUri` points at.

## Photo preservation (fixes the rehearsal's photoless publish)

`cdn.bsky.app` sends no `access-control-allow-origin`, so browser-side photo fetches of imported photos fail CORS and publishes went out photoless. Now when a fresh photo fetch/upload fails, re-publish carries the target record's **existing embed** forward — blob refs are same-repo, so reuse is valid and a re-publish never *loses* a photo it can't rebuild. (First-publish of a CORS-blocked external photo is still photoless — the `sync.getBlob` fallback remains follow-up work.)

## Verification

- `tsc --noEmit` clean on shared + web (pre-existing unrelated errors aside)
- Broker page renders clean; protocol change is additive (`adoptUri?` optional — old requesters unaffected)
- Manual rehearsal planned: import own record → CTA shows published state → edit → re-publish → original updated (same URI, new CID), photo intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)