### PR TITLE
Serve client-metadata.json with CORS — hosted-origin Bluesky sign-in was broken

### DIFF
--- a/packages/marketing/public/_headers
+++ b/packages/marketing/public/_headers
@@ -1,0 +1,8 @@
+# AT Protocol OAuth client metadata must be browser-fetchable from the
+# app origins (my.pantryhost.app): BrowserOAuthClient.load() does a
+# client-side fetch of the client_id URL, which is cross-origin from
+# every origin that isn't pantryhost.app itself. Without this header
+# hosted-origin sign-in fails with "Failed to fetch" before the OAuth
+# dance even starts. Public document, no credentials — `*` is correct.
+/client-metadata.json
+  Access-Control-Allow-Origin: *


### PR DESCRIPTION
## What

Adds `packages/marketing/public/_headers` so `/client-metadata.json` is served with `Access-Control-Allow-Origin: *`.

## Why

`BrowserOAuthClient.load({ clientId })` fetches the client_id URL **from the browser**. On `my.pantryhost.app` that's a cross-origin fetch to `pantryhost.app`, which served the metadata with no CORS header — so `BlueskyAuth` init fails with `TypeError: Failed to fetch` and hosted-origin sign-in never gets to the OAuth dance. Every successful sign-in so far happened on loopback (`127.0.0.1`), where the client is constructed locally without fetching metadata.

The publish-broker rollout (#38, merged) makes `my.pantryhost.app` the sign-in origin for all self-hosted publishers, so this is now load-bearing: reproduced on the live site — console shows the init failure on `/publish-broker`.

## Verification

- `vite build` copies `_headers` into `dist/`
- `wrangler dev` (Workers assets honor `_headers`): `curl -I -H "Origin: https://my.pantryhost.app" http://localhost:8788/client-metadata.json` → `Access-Control-Allow-Origin: *` ✅
- Post-merge check: same curl against `https://pantryhost.app/client-metadata.json`, then confirm sign-in works on `https://my.pantryhost.app/publish-broker`

The client metadata is a public document fetched without credentials — `*` is the correct scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)