### PR TITLE
fix(publish): fetch Bluesky CDN photos via PDS sync.getBlob (CORS)

### DIFF
--- a/packages/shared/src/atproto-broker.ts
+++ b/packages/shared/src/atproto-broker.ts
@@ -38,7 +38,7 @@
  * app passwords) are tracked in #37.
  */
 
-import type { PublishableMenu, PublishableRecipe } from './atproto-publish';
+import { fetchPhotoBlob, type PublishableMenu, type PublishableRecipe } from './atproto-publish';
 
 // ── Protocol ─────────────────────────────────────────────────────────────
 
@@ -176,8 +176,10 @@ export async function collectPhotoBlobs(
           if (blob) out[url] = blob;
           return;
         }
-        const res = await fetch(url);
-        if (res.ok) out[url] = await res.blob();
+        // Default resolver knows the PDS sync.getBlob path for
+        // CORS-blocked Bluesky CDN URLs, not just plain fetch.
+        const blob = await fetchPhotoBlob(url);
+        if (blob) out[url] = blob;
       } catch {
         /* skip — broker will publish without this photo */
       }

--- a/packages/shared/src/atproto-publish.ts
+++ b/packages/shared/src/atproto-publish.ts
@@ -39,6 +39,7 @@ import type {
   BlueskyRecipeImage,
 } from './bluesky';
 import { getRecord } from './bluesky';
+import { xrpcBaseFor } from './atproto-pds';
 import { minutesToIsoDuration } from './recipe-api';
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -233,8 +234,38 @@ const MAX_PHOTO_BYTES = 950_000;
  *  app's own upload pipeline keeps (1200w) plus slack for portrait. */
 const MAX_PHOTO_DIM = 1600;
 
-/** Default `fetchPhoto` — plain fetch. Works for the app's
- *  same-origin `/uploads/…` paths, `blob:`/`data:` URLs, and
+/** Bluesky CDN image URLs (what the import path stores as `photoUrl`)
+ *  embed the author DID and the blob CID:
+ *    https://cdn.bsky.app/img/{preset}/plain/{did}/{cid}@{fmt}
+ *  The CDN sends no CORS headers, so a browser can never fetch these
+ *  directly. */
+function parseBskyCdnUrl(url: string): { did: string; cid: string } | null {
+  const m = url.match(/^https:\/\/cdn\.bsky\.app\/img\/[^/]+\/plain\/(did:[^/@]+)\/([a-z2-7]+)@\w+$/i);
+  return m ? { did: m[1], cid: m[2] } : null;
+}
+
+/** Fetch a blob straight from its author's PDS via
+ *  `com.atproto.sync.getBlob` — a public, CORS-enabled endpoint. This
+ *  is how CDN-referenced photos become publishable from the browser,
+ *  and it returns the ORIGINAL bytes rather than the CDN's
+ *  thumbnail/re-encode. Returns null on any failure. */
+async function fetchBlobFromPds(did: string, cid: string): Promise<Blob | null> {
+  try {
+    const base = await xrpcBaseFor(did);
+    const res = await fetch(
+      `${base}/com.atproto.sync.getBlob?did=${encodeURIComponent(did)}&cid=${encodeURIComponent(cid)}`,
+    );
+    if (!res.ok) return null;
+    return await res.blob();
+  } catch {
+    return null;
+  }
+}
+
+/** Default `fetchPhoto` — plain fetch, with a PDS `sync.getBlob`
+ *  path for Bluesky CDN URLs (the CDN itself is CORS-blocked; the
+ *  author's PDS serves the same blob with CORS). Also covers the
+ *  app's same-origin `/uploads/…` paths, `blob:`/`data:` URLs, and
  *  external URLs whose hosts send CORS headers. Returns null (never
  *  throws) when the URL can't be fetched — a missing photo must not
  *  block a publish. */
@@ -245,6 +276,13 @@ export async function fetchPhotoBlob(photoUrl: string): Promise<Blob | null> {
     // package (see PublishOptions.fetchPhoto).
     console.warn('[atproto-publish] opfs:// photo needs a fetchPhoto override; skipping', photoUrl);
     return null;
+  }
+  const cdn = parseBskyCdnUrl(photoUrl);
+  if (cdn) {
+    const viaPds = await fetchBlobFromPds(cdn.did, cdn.cid);
+    if (viaPds) return viaPds;
+    // fall through — the plain fetch below almost certainly fails
+    // CORS, but costs nothing to try.
   }
   try {
     const res = await fetch(photoUrl);


### PR DESCRIPTION
## Problem

Imported recipes and menus store their `photoUrl` as a `cdn.bsky.app` URL. That CDN sends no `access-control-allow-origin` header, so a browser can never fetch the bytes. On re-publish (adopt-own-records or a fresh publish of an imported copy), the photo blob couldn't be collected — records silently lost their photo.

## Fix

The CDN URL embeds everything we need:

```
https://cdn.bsky.app/img/{preset}/plain/{did}/{cid}@{fmt}
```

`parseBskyCdnUrl` extracts the author `did` + blob `cid`; `fetchBlobFromPds` resolves the author's PDS (`xrpcBaseFor`) and fetches the blob from `com.atproto.sync.getBlob` — a **public, CORS-enabled** endpoint that returns the **original** bytes rather than the CDN's re-encode.

- `fetchPhotoBlob` tries the PDS path first for CDN URLs, falling through to plain fetch otherwise.
- The broker's `collectPhotoBlobs` default resolver now uses `fetchPhotoBlob`, so **broker-mode** publishes get the same path.

Verified via curl: `sync.getBlob?did=…&cid=bafkreid6c3rylcynstoddil…` returns `access-control-allow-origin: *`, `content-type: image/jpeg`, 227808 bytes.

## Scope / follow-up

This is the **pure-client** fix — no infrastructure. It covers the entire import-then-publish flow (every imported photo is a `cdn.bsky.app` URL).

Arbitrary external photo hosts (loveandlemons.com, etc.) have no client-side option and still need a proxy — **deferred** (would live on `feed.pantryhost.app` alongside the existing recipe-HTML proxy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)