### PR TITLE
feat(publish): proxy cross-origin recipe photos via feed box

### DIFF
--- a/packages/feed/src/server.ts
+++ b/packages/feed/src/server.ts
@@ -794,6 +794,99 @@ app.post('/api/fetch-recipe', express.json(), async (req, res) => {
   res.json({ title, ingredients: [] });
 });
 
+// ── Image proxy ───────────────────────────────────────────────
+// GET /api/image-proxy?url=…  → the image bytes, with CORS.
+//
+// Publishing an imported recipe to Bluesky re-uploads its photo, but
+// the browser can't fetch an arbitrary external host's image (no CORS
+// header). Bluesky-CDN photos take a client-side path (author PDS
+// sync.getBlob); every OTHER host — food blogs, loveandlemons.com,
+// etc. — has no client option and comes through here. The bytes
+// transit this Fly box; nothing is stored.
+//
+// SSRF guard: only http(s), and reject hosts that are (or look like)
+// internal — literal private/link-local IPs, localhost, *.local /
+// *.internal. Not airtight against DNS rebinding, but this box holds
+// no internal-network secrets and returns only image/* bytes.
+
+const IMAGE_PROXY_MAX_BYTES = 15_000_000;
+
+function isBlockedHost(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (h === 'localhost' || h.endsWith('.local') || h.endsWith('.internal')) return true;
+  // IPv4 literal private / loopback / link-local ranges.
+  const v4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const [a, b] = [Number(v4[1]), Number(v4[2])];
+    if (a === 10 || a === 127 || a === 0) return true;
+    if (a === 169 && b === 254) return true; // link-local + cloud metadata
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    return false;
+  }
+  // IPv6 loopback / unique-local / link-local.
+  if (h === '::1' || h.startsWith('fc') || h.startsWith('fd') || h.startsWith('fe80')) return true;
+  return false;
+}
+
+app.get('/api/image-proxy', async (req, res) => {
+  const url = typeof req.query.url === 'string' ? req.query.url : '';
+  if (!url) { res.status(400).json({ error: 'url is required' }); return; }
+
+  let target: URL;
+  try {
+    target = new URL(url);
+  } catch {
+    res.status(400).json({ error: 'invalid url' });
+    return;
+  }
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    res.status(400).json({ error: 'only http(s) urls are supported' });
+    return;
+  }
+  if (isBlockedHost(target.hostname)) {
+    res.status(403).json({ error: 'host not allowed' });
+    return;
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; PantryHostBot/1.0)' },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err) {
+    res.status(502).json({ error: `failed to fetch image: ${(err as Error).message}` });
+    return;
+  }
+  if (!upstream.ok) {
+    res.status(502).json({ error: `upstream returned HTTP ${upstream.status}` });
+    return;
+  }
+
+  const contentType = upstream.headers.get('content-type') ?? '';
+  if (!contentType.startsWith('image/')) {
+    res.status(415).json({ error: `not an image (content-type: ${contentType || 'unknown'})` });
+    return;
+  }
+  const declaredLength = Number(upstream.headers.get('content-length') ?? '0');
+  if (declaredLength > IMAGE_PROXY_MAX_BYTES) {
+    res.status(413).json({ error: 'image too large' });
+    return;
+  }
+
+  const buf = Buffer.from(await upstream.arrayBuffer());
+  if (buf.length > IMAGE_PROXY_MAX_BYTES) {
+    res.status(413).json({ error: 'image too large' });
+    return;
+  }
+
+  res.setHeader('Content-Type', contentType);
+  res.setHeader('Cache-Control', 'public, max-age=86400');
+  res.send(buf);
+});
+
 app.listen(PORT, '0.0.0.0', () => {
   console.log(`[api] Listening on port ${PORT}`);
   startFirehose();

--- a/packages/shared/src/atproto-publish.ts
+++ b/packages/shared/src/atproto-publish.ts
@@ -262,13 +262,43 @@ async function fetchBlobFromPds(did: string, cid: string): Promise<Blob | null> 
   }
 }
 
+/** Cross-origin image proxy on the feed box — fetches an arbitrary
+ *  external photo server-side and returns it with CORS headers. The
+ *  last resort for hosts (food blogs etc.) that send no CORS header
+ *  and aren't Bluesky-CDN (those take the PDS path above). */
+const IMAGE_PROXY_URL = 'https://feed.pantryhost.app/api/image-proxy';
+
+/** True for an absolute http(s) URL on some OTHER origin — the only
+ *  case the proxy helps. Same-origin `/uploads/…`, relative paths,
+ *  and `blob:`/`data:` are fetched directly and never proxied. */
+function isCrossOriginHttp(url: string): boolean {
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    if (typeof location !== 'undefined' && u.origin === location.origin) return false;
+    return true;
+  } catch {
+    return false; // relative or unparseable — not a proxy candidate
+  }
+}
+
+async function fetchViaImageProxy(url: string): Promise<Blob | null> {
+  try {
+    const res = await fetch(`${IMAGE_PROXY_URL}?url=${encodeURIComponent(url)}`);
+    if (!res.ok) return null;
+    return await res.blob();
+  } catch {
+    return null;
+  }
+}
+
 /** Default `fetchPhoto` — plain fetch, with a PDS `sync.getBlob`
  *  path for Bluesky CDN URLs (the CDN itself is CORS-blocked; the
- *  author's PDS serves the same blob with CORS). Also covers the
- *  app's same-origin `/uploads/…` paths, `blob:`/`data:` URLs, and
- *  external URLs whose hosts send CORS headers. Returns null (never
- *  throws) when the URL can't be fetched — a missing photo must not
- *  block a publish. */
+ *  author's PDS serves the same blob with CORS) and a feed-box image
+ *  proxy fallback for any OTHER cross-origin host that blocks CORS.
+ *  Also covers the app's same-origin `/uploads/…` paths and
+ *  `blob:`/`data:` URLs. Returns null (never throws) when the URL
+ *  can't be fetched — a missing photo must not block a publish. */
 export async function fetchPhotoBlob(photoUrl: string): Promise<Blob | null> {
   if (typeof fetch === 'undefined') return null;
   if (photoUrl.startsWith('opfs://')) {
@@ -286,12 +316,16 @@ export async function fetchPhotoBlob(photoUrl: string): Promise<Blob | null> {
   }
   try {
     const res = await fetch(photoUrl);
-    if (!res.ok) return null;
-    return await res.blob();
+    if (res.ok) return await res.blob();
   } catch {
-    console.warn('[atproto-publish] photo fetch failed (CORS?); publishing without it', photoUrl);
-    return null;
+    /* CORS or network — try the proxy below for cross-origin hosts */
   }
+  if (isCrossOriginHttp(photoUrl)) {
+    const viaProxy = await fetchViaImageProxy(photoUrl);
+    if (viaProxy) return viaProxy;
+  }
+  console.warn('[atproto-publish] photo fetch failed (CORS?); publishing without it', photoUrl);
+  return null;
 }
 
 /** Decode, downscale to MAX_PHOTO_DIM, and re-encode as JPEG until


### PR DESCRIPTION
## Problem

`v0.6.1` fixed Bluesky-CDN photos (fetched from the author's PDS via `com.atproto.sync.getBlob`). But photos imported from **arbitrary external hosts** — food blogs, loveandlemons.com, etc. — still can't be fetched by the browser to re-upload on publish: those hosts send no CORS header and there is no client-side workaround. On publish, the record loses its photo.

## Fix

New `GET /api/image-proxy?url=…` on the feed box (`feed.pantryhost.app`, already the home of the recipe-URL fetch proxy). It fetches the image **server-side** and returns the bytes with `Access-Control-Allow-Origin: *`.

Guards:
- **http(s) only** — `file://` etc. rejected (400)
- **SSRF block** — private / loopback / link-local IP literals, `localhost`, `*.local`, `*.internal`, and the `169.254.169.254` cloud-metadata address → 403
- **15 MB cap** (content-length + actual body) → 413
- **`image/*` content-type required** → 415
- **24 h cache**

The bytes transit the Fly box; nothing is stored.

`fetchPhotoBlob` (shared) now falls back to the proxy for cross-origin http(s) hosts **after** a direct fetch fails. Bluesky CDN still takes the PDS path first; same-origin `/uploads`, `blob:`, and `data:` are never proxied.

## Verification (local, port 3002)

| Case | Result |
|---|---|
| Real external JPEG (loveandlemons) | 200 `image/jpeg`, 301 KB, `ACAO: *`, `max-age=86400` |
| `localhost` | 403 |
| `192.168.1.1` | 403 |
| `169.254.169.254` metadata | 403 |
| HTML page | 415 |
| missing `url` | 400 |
| `file://` | 400 |

Typecheck: 0 new errors in `shared` and `feed`.

## Deploy note

The feed box must be redeployed to Fly for the endpoint to go live (`wrangler`/Docker per the feed package). The client fallback ships with the next app/web release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)