### PR TITLE
feat(atproto): OAuth sovereignty for self-hosters (own client-metadata.json)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,25 @@ AI_API_KEY=
 # prefix used in the GSSP fetch.
 REX_INTERNAL_ORIGIN=http://127.0.0.1:4001
 
+# ── Share to Bluesky (AT Protocol publishing) ──────────────────────────────
+# Publishing is entirely client-side (browser → your PDS); the backend isn't
+# involved. All three vars are optional.
+#
+# Safety default: everywhere except http://127.0.0.1, publishing is dry-run
+# (records are previewed, never written) until you explicitly opt in.
+# ATPROTO_PUBLISH_DRY_RUN=false   # false = real publishes on this instance
+#
+# OAuth sovereignty (optional — off the loopback origin, sign-in otherwise
+# routes through the pantryhost.app publish broker). To sign in directly
+# against THIS instance instead, host your own client-metadata.json over
+# public HTTPS and point the app at it. Setting this also disables the broker.
+#   1. Generate the doc for your public URL:
+#        npx tsx packages/app/scripts/gen-client-metadata.ts https://recipes.example.com \
+#          -o packages/app/public/client-metadata.json
+#   2. Serve it at https://recipes.example.com/client-metadata.json
+#   3. Set the var to that URL. See docs/self-hosted-oauth.md.
+# ATPROTO_CLIENT_ID=https://recipes.example.com/client-metadata.json
+
 # Feature flags (all default to true)
 # ENABLE_IMAGE_PROCESSING=false  # Skip sharp variants on upload, save disk space (Pi)
 SHOW_COCKTAILDB=true              # Set to false to hide the TheCocktailDB tab on /recipes/import.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,6 +454,8 @@ GRAPHQL_PORT=4001                                               # default 4001
 DEFAULT_THEME=claude                                            # auto-set by launch.json
 MCP_PORT=5001                                                   # default 5001, MCP HTTP mode
 MCP_API_KEY=                                                    # optional, bearer auth for MCP HTTP
+ATPROTO_PUBLISH_DRY_RUN=false                                   # Share to Bluesky: false = real publishes; default dry-run everywhere except 127.0.0.1
+ATPROTO_CLIENT_ID=                                              # optional, OAuth sovereignty: your own hosted client-metadata.json URL (disables the pantryhost.app broker). See docs/self-hosted-oauth.md
 GRAPHQL_URL=http://localhost:4001/graphql                       # MCP server's GraphQL target
 APP_URL=http://localhost:3000                                   # MCP server's target for /api/upload (set_recipe_photo)
 ENABLE_IMAGE_PROCESSING=true                                    # false: skip sharp variants, save disk (Pi)

--- a/docs/self-hosted-oauth.md
+++ b/docs/self-hosted-oauth.md
@@ -1,0 +1,139 @@
+# Self-hosted OAuth sovereignty (Share to Bluesky)
+
+Publishing recipes to Bluesky (Share to Bluesky) is **entirely client-side**:
+your browser talks OAuth + DPoP directly to your PDS and writes the records.
+The Pantry Host backend is never involved.
+
+AT Protocol OAuth identifies a client by a **public HTTPS document** whose URL
+*is* the `client_id`. That document lists the `redirect_uris` the authorization
+server will hand a token back to. A self-hosted instance reached at, say,
+`https://recipes.example.com` therefore can't just complete OAuth on its own —
+the hosted `pantryhost.app` client metadata doesn't list your callback.
+
+Pantry Host gives you **two ways** to publish from a self-hosted instance:
+
+| Path | What happens | Dependency |
+|---|---|---|
+| **Broker (default)** | Off `127.0.0.1`, sign-in + writes route through a popup on `my.pantryhost.app/publish-broker`. Your browser still writes to *your* PDS; pantryhost.app just holds the OAuth client. | Relies on pantryhost.app being up. |
+| **Sovereign (this doc)** | You host your own `client-metadata.json`; OAuth completes directly against your origin. No pantryhost.app in the loop. | You run a public HTTPS endpoint. |
+
+Both write to your own repo on your own PDS. The broker is the zero-config
+default; sovereignty is for self-hosters who want no third-party dependency in
+their publish path.
+
+> **Loopback shortcut:** reaching the app at `http://127.0.0.1:3000` on the box
+> itself uses the AT spec's loopback client and needs none of this. Sovereignty
+> matters when you reach the instance at a real address — a LAN IP, a Tailscale
+> hostname, or a reverse-proxied domain.
+
+## Requirements
+
+- The instance must be reachable over **public HTTPS** at a stable origin
+  (e.g. `https://recipes.example.com`). AT OAuth requires the `client_id`
+  document to be fetchable by the authorization server over HTTPS — a
+  `.local`/LAN-only/`http://` origin will not work for the sovereign path.
+  (A Tailscale-serve HTTPS hostname like `https://box.tailXXXX.ts.net` works.)
+- The app must serve a static file at `/client-metadata.json` at that origin.
+
+## Steps
+
+### 1. Generate your client metadata
+
+```bash
+npx tsx packages/app/scripts/gen-client-metadata.ts https://recipes.example.com \
+  -o packages/app/public/client-metadata.json
+```
+
+Optionally name the client (shown on the Bluesky consent screen):
+
+```bash
+npx tsx packages/app/scripts/gen-client-metadata.ts https://recipes.example.com \
+  --name "Example Kitchen" -o packages/app/public/client-metadata.json
+```
+
+Omit `-o` to print to stdout instead. The generated document looks like:
+
+```json
+{
+  "client_id": "https://recipes.example.com/client-metadata.json",
+  "client_name": "Pantry Host (self-hosted)",
+  "client_uri": "https://recipes.example.com",
+  "redirect_uris": ["https://recipes.example.com/oauth/bluesky/callback"],
+  "scope": "atproto repo:exchange.recipe.recipe repo:exchange.recipe.collection blob:image/*",
+  "token_endpoint_auth_method": "none",
+  "application_type": "web",
+  "dpop_bound_access_tokens": true
+}
+```
+
+The `scope`, callback path, and grant/response types come from
+`@pantry-host/shared/atproto-client` — the same source of truth the running app
+uses to request the token, so your document can't drift from what the client
+asks for.
+
+### 2. Serve it over HTTPS
+
+Files in `packages/app/public/` are served at the app root, so once the app is
+built and running behind HTTPS the document is live at:
+
+```
+https://recipes.example.com/client-metadata.json
+```
+
+Confirm it before continuing:
+
+```bash
+curl -s https://recipes.example.com/client-metadata.json | head
+```
+
+The `client_id` inside must exactly equal the URL you fetched it from.
+
+### 3. Point the app at it
+
+Set the environment variable and restart:
+
+```bash
+# .env.local (Rex reads this via _document.tsx → <meta name="atproto-client-id">)
+ATPROTO_CLIENT_ID=https://recipes.example.com/client-metadata.json
+```
+
+- **Rex app (Tier 2):** `_document.tsx` emits
+  `<meta name="atproto-client-id" content="…">`. Rebuild + restart Rex so the
+  meta tag is served (Rex doesn't inline `process.env` into the client bundle —
+  same reason the dry-run flag rides a meta tag).
+- **Vite web (Tier 1):** set `VITE_ATPROTO_CLIENT_ID` at build time instead.
+
+Presence of this override does two things client-side:
+
+1. `getProdClientId()` loads *your* metadata for OAuth.
+2. `shouldUseBroker()` returns `false`, so sign-in runs directly against your
+   origin instead of the pantryhost.app broker popup.
+
+### 4. Turn off dry-run (if you haven't)
+
+Publishing defaults to dry-run everywhere except `127.0.0.1`. To write real
+records:
+
+```bash
+ATPROTO_PUBLISH_DRY_RUN=false
+```
+
+Rebuild + restart. Now Share to Bluesky signs in against your own instance and
+writes to your PDS with no pantryhost.app involvement.
+
+## Verifying
+
+1. Open the instance at its public HTTPS origin.
+2. On a recipe, click **Share to Bluesky**. The consent screen should show your
+   `client_name` and redirect back to `https://recipes.example.com/oauth/bluesky/callback`
+   — no `my.pantryhost.app` popup.
+3. After confirming, the record lands in your repo. Check it:
+   ```bash
+   curl -s "https://<your-pds>/xrpc/com.atproto.repo.listRecords?repo=<your-did>&collection=exchange.recipe.recipe"
+   ```
+
+## Reverting to the broker
+
+Unset `ATPROTO_CLIENT_ID` (and remove the generated `client-metadata.json` if
+you like), rebuild, restart. Off-loopback origins fall back to the
+`my.pantryhost.app` broker automatically.

--- a/packages/app/pages/_document.tsx
+++ b/packages/app/pages/_document.tsx
@@ -58,6 +58,15 @@ export default function Document() {
         {process.env.ATPROTO_PUBLISH_DRY_RUN && (
           <meta name="atproto-publish-dry-run" content={process.env.ATPROTO_PUBLISH_DRY_RUN} />
         )}
+        {/* OAuth sovereignty: a self-hoster who serves their own
+            client-metadata.json points the app at it here. Its presence
+            also flips shouldUseBroker() off so OAuth runs directly against
+            this instance instead of the pantryhost.app broker. Rides the
+            same meta channel as dry-run because Rex doesn't inline
+            process.env into the client bundle. See docs/self-hosted-oauth.md. */}
+        {process.env.ATPROTO_CLIENT_ID && (
+          <meta name="atproto-client-id" content={process.env.ATPROTO_CLIENT_ID} />
+        )}
         {/* SHOW_COCKTAILDB no longer injected here — RecipeImportPage fetches
             it from /api/settings-read so /settings overrides take effect
             without a server restart. */}

--- a/packages/app/scripts/gen-client-metadata.ts
+++ b/packages/app/scripts/gen-client-metadata.ts
@@ -1,0 +1,80 @@
+/**
+ * Generate a `client-metadata.json` for a self-hosted Pantry Host instance
+ * that wants OAuth *sovereignty* — completing Bluesky sign-in against its own
+ * origin instead of routing through the pantryhost.app publish broker.
+ *
+ * AT Protocol OAuth identifies a client by a public HTTPS document whose URL
+ * IS the `client_id`. To publish from `https://recipes.example.com`, host the
+ * generated JSON at `https://recipes.example.com/client-metadata.json` and set
+ * `ATPROTO_CLIENT_ID=https://recipes.example.com/client-metadata.json` in the
+ * app's environment. See docs/self-hosted-oauth.md for the full walkthrough.
+ *
+ * Usage:
+ *   npx tsx packages/app/scripts/gen-client-metadata.ts https://recipes.example.com
+ *   npx tsx packages/app/scripts/gen-client-metadata.ts https://recipes.example.com --name "My Kitchen"
+ *   npx tsx packages/app/scripts/gen-client-metadata.ts https://recipes.example.com -o packages/app/public/client-metadata.json
+ *
+ * With no -o/--out, the document is printed to stdout.
+ */
+
+import { promises as fs } from 'fs';
+import { buildClientMetadata } from '@pantry-host/shared/atproto-client';
+
+function parseArgs(argv: string[]): {
+  baseUrl?: string;
+  name?: string;
+  out?: string;
+} {
+  const out: { baseUrl?: string; name?: string; out?: string } = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--name') {
+      out.name = argv[++i];
+    } else if (arg === '-o' || arg === '--out') {
+      out.out = argv[++i];
+    } else if (!arg.startsWith('-') && !out.baseUrl) {
+      out.baseUrl = arg;
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const { baseUrl, name, out } = parseArgs(process.argv.slice(2));
+
+  if (!baseUrl) {
+    console.error(
+      'Usage: npx tsx packages/app/scripts/gen-client-metadata.ts <https-base-url> [--name "Display Name"] [-o out.json]\n' +
+        '\n' +
+        'Example:\n' +
+        '  npx tsx packages/app/scripts/gen-client-metadata.ts https://recipes.example.com',
+    );
+    process.exit(1);
+  }
+
+  let metadata;
+  try {
+    metadata = name ? buildClientMetadata(baseUrl, name) : buildClientMetadata(baseUrl);
+  } catch (err) {
+    console.error(`✗ ${(err as Error).message}`);
+    process.exit(1);
+    return;
+  }
+
+  const json = JSON.stringify(metadata, null, 2) + '\n';
+
+  if (out) {
+    await fs.writeFile(out, json, 'utf8');
+    console.error(`✓ Wrote ${out}`);
+    console.error(`  Host it at:   ${metadata.client_id}`);
+    console.error(`  Then set:     ATPROTO_CLIENT_ID=${metadata.client_id}`);
+    console.error(`  Callback URI: ${metadata.redirect_uris[0]}`);
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -70,6 +70,7 @@
     "./components/QRCodeModal": "./src/components/QRCodeModal.tsx",
     "./components/ImageBoundary": "./src/components/ImageBoundary.tsx",
     "./sql/schema": "./src/sql/schema.ts",
+    "./atproto-client": "./src/atproto-client.ts",
     "./atproto-publish": "./src/atproto-publish.ts",
     "./atproto-broker": "./src/atproto-broker.ts",
     "./pds-published": "./src/pds-published.ts",

--- a/packages/shared/src/atproto-broker.ts
+++ b/packages/shared/src/atproto-broker.ts
@@ -137,15 +137,43 @@ export function brokerUrl(): string {
   return DEFAULT_BROKER_URL;
 }
 
+/** True when this instance is configured with its OWN atproto OAuth
+ *  client — a self-hosted `client-metadata.json` whose `redirect_uris`
+ *  include this instance's callback. Such an instance completes OAuth
+ *  directly against its own origin and needs no pantryhost.app broker
+ *  (OAuth *sovereignty*; see docs/self-hosted-oauth.md). Resolution
+ *  mirrors getProdClientId(): Vite env → `atproto-client-id` meta tag
+ *  (Rex) → process.env. Presence of an override is the signal — the
+ *  hosted default doesn't count (its redirect_uris don't cover a
+ *  self-hosted origin, which is exactly why the broker exists). */
+export function hasSelfHostedOAuthClient(): boolean {
+  try {
+    // @ts-expect-error import.meta.env is a Vite-ism (see brokerUrl()).
+    if (import.meta.env.VITE_ATPROTO_CLIENT_ID) return true;
+  } catch {
+    /* not vite */
+  }
+  if (typeof document !== 'undefined') {
+    if (document.querySelector('meta[name="atproto-client-id"]')?.getAttribute('content')) {
+      return true;
+    }
+  }
+  if (typeof process !== 'undefined' && process.env?.ATPROTO_CLIENT_ID) return true;
+  return false;
+}
+
 /** True when this origin cannot complete AT OAuth itself and should
  *  publish through the broker popup instead: not the spec loopback
- *  (127.0.0.1 / [::1]) and not an origin the hosted client's
- *  redirect_uris cover. Deliberately includes `localhost` — the spec
- *  rejects it for loopback OAuth, but the broker works fine there. */
+ *  (127.0.0.1 / [::1]), not an origin the hosted client's redirect_uris
+ *  cover, and not a sovereign instance running its own OAuth client.
+ *  Deliberately includes `localhost` — the spec rejects it for loopback
+ *  OAuth, but the broker works fine there. */
 export function shouldUseBroker(): boolean {
   if (typeof window === 'undefined') return false;
   const { hostname, origin } = window.location;
   if (hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1') return false;
+  // A sovereign self-hoster (own client-metadata.json) does direct OAuth.
+  if (hasSelfHostedOAuthClient()) return false;
   const brokerOrigin = new URL(brokerUrl()).origin;
   // Direct OAuth works on the hosted origins themselves (and on the
   // broker origin — a broker popup opening a broker would be silly).

--- a/packages/shared/src/atproto-client.ts
+++ b/packages/shared/src/atproto-client.ts
@@ -1,0 +1,88 @@
+/**
+ * AT Protocol OAuth client identity — the non-React pieces shared by the
+ * auth client (packages/shared/src/contexts/BlueskyAuth.tsx) and the
+ * self-hoster's client-metadata generator (packages/app/scripts/gen-client-metadata.ts).
+ *
+ * A Pantry Host instance authenticates to a user's PDS as an OAuth client
+ * identified by a public HTTPS `client-metadata.json`. The hosted apps use
+ * pantryhost.app's document; a self-hoster who wants OAuth *sovereignty*
+ * (no dependency on the pantryhost.app publish broker) hosts their own,
+ * with their instance's callback in `redirect_uris`, and points the app at
+ * it via `ATPROTO_CLIENT_ID` / `VITE_ATPROTO_CLIENT_ID`. See
+ * docs/self-hosted-oauth.md.
+ *
+ * Kept React-free so the generator script can import it without pulling a
+ * context module (and its React dependency) into a Node CLI.
+ */
+
+/** The hosted client identity — pantryhost.app's published metadata.
+ *  Default when no `ATPROTO_CLIENT_ID` override is configured. */
+export const DEFAULT_CLIENT_METADATA_URL =
+  'https://pantryhost.app/client-metadata.json';
+
+/** Everything Share-to-Bluesky needs, as granular atproto OAuth scopes:
+ *  full CRUD on both exchange.recipe.* collections (publish, re-publish via
+ *  putRecord, unpublish via deleteRecord) plus image blob upload for recipe
+ *  photos. The bare `atproto` scope only grants identity — PDSes enforce
+ *  per-collection `repo:` scopes on record writes. This is the single source
+ *  of truth: BlueskyAuth bakes it into sign-in requests and the loopback
+ *  client_id, and buildClientMetadata() writes it into hosted metadata, so a
+ *  self-hoster's document can never drift from what the client requests. */
+export const ATPROTO_PUBLISH_OAUTH_SCOPE =
+  'atproto repo:exchange.recipe.recipe repo:exchange.recipe.collection blob:image/*';
+
+/** The callback route both packages mount for the OAuth redirect. */
+export const OAUTH_CALLBACK_PATH = '/oauth/bluesky/callback';
+
+export interface ClientMetadata {
+  client_id: string;
+  client_name: string;
+  client_uri: string;
+  logo_uri: string;
+  tos_uri: string;
+  policy_uri: string;
+  redirect_uris: string[];
+  grant_types: string[];
+  response_types: string[];
+  scope: string;
+  token_endpoint_auth_method: string;
+  application_type: string;
+  dpop_bound_access_tokens: boolean;
+}
+
+/**
+ * Build a `client-metadata.json` document for a self-hosted instance served
+ * over public HTTPS at `baseUrl` (e.g. `https://recipes.example.com`). The
+ * `client_id` is the document's own public URL — the AT authorization server
+ * fetches it to learn the client, so it must resolve to exactly this JSON.
+ *
+ * @param baseUrl  Public HTTPS origin (no trailing slash needed) where the
+ *                 instance — and this metadata document — are reachable.
+ * @param clientName Optional display name shown on the PDS consent screen.
+ */
+export function buildClientMetadata(
+  baseUrl: string,
+  clientName = 'Pantry Host (self-hosted)',
+): ClientMetadata {
+  const base = baseUrl.replace(/\/+$/, '');
+  if (!/^https:\/\//i.test(base)) {
+    throw new Error(
+      `client-metadata base URL must be public HTTPS, got: ${baseUrl}`,
+    );
+  }
+  return {
+    client_id: `${base}/client-metadata.json`,
+    client_name: clientName,
+    client_uri: base,
+    logo_uri: `${base}/icon-512.png`,
+    tos_uri: base,
+    policy_uri: base,
+    redirect_uris: [`${base}${OAUTH_CALLBACK_PATH}`],
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    scope: ATPROTO_PUBLISH_OAUTH_SCOPE,
+    token_endpoint_auth_method: 'none',
+    application_type: 'web',
+    dpop_bound_access_tokens: true,
+  };
+}

--- a/packages/shared/src/contexts/BlueskyAuth.tsx
+++ b/packages/shared/src/contexts/BlueskyAuth.tsx
@@ -36,6 +36,14 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import {
+  ATPROTO_PUBLISH_OAUTH_SCOPE,
+  DEFAULT_CLIENT_METADATA_URL,
+} from '../atproto-client';
+
+// Re-exported for back-compat: existing consumers import the scope from
+// this context module. Its home is now the React-free ./atproto-client.
+export { ATPROTO_PUBLISH_OAUTH_SCOPE };
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -92,8 +100,12 @@ const BlueskyAuthContext = createContext<BlueskyAuthState>(DEFAULT_STATE);
 
 // ── Client construction ──────────────────────────────────────────────────
 
-/** Read the prod client-metadata URL — override-able via env for
- *  staging. Defaults to pantryhost.app. */
+/** Read the prod client-metadata URL — override-able so a self-hoster
+ *  can point at THEIR OWN hosted `client-metadata.json` for OAuth
+ *  sovereignty (see docs/self-hosted-oauth.md). Resolution order mirrors
+ *  brokerUrl()/isDryRun(): Vite env (web build) → `atproto-client-id`
+ *  meta tag (Rex — process.env isn't inlined into its client bundle) →
+ *  process.env (bundlers that do inline it) → hosted pantryhost.app. */
 function getProdClientId(): string {
   try {
     // Exact `import.meta.env.VITE_X` token required — Vite's env
@@ -105,22 +117,17 @@ function getProdClientId(): string {
   } catch {
     /* not vite */
   }
+  if (typeof document !== 'undefined') {
+    const meta = document
+      .querySelector('meta[name="atproto-client-id"]')
+      ?.getAttribute('content');
+    if (meta) return meta;
+  }
   if (typeof process !== 'undefined' && process.env?.ATPROTO_CLIENT_ID) {
     return process.env.ATPROTO_CLIENT_ID;
   }
-  return 'https://pantryhost.app/client-metadata.json';
+  return DEFAULT_CLIENT_METADATA_URL;
 }
-
-/** Everything Share-to-Bluesky needs, as granular atproto OAuth
- *  scopes: full CRUD on both exchange.recipe.* collections (publish,
- *  re-publish via putRecord, unpublish via deleteRecord) plus image
- *  blob upload for recipe photos. The bare `atproto` scope only
- *  grants identity — PDSes enforce per-collection `repo:` scopes on
- *  record writes. Must match the `scope` in
- *  packages/marketing/public/client-metadata.json (hosted client)
- *  and is baked into the loopback client_id below (dev). */
-export const ATPROTO_PUBLISH_OAUTH_SCOPE =
-  'atproto repo:exchange.recipe.recipe repo:exchange.recipe.collection blob:image/*';
 
 /** Loopback-safe or hosted-metadata-safe? We key off origin. The
  *  atproto OAuth spec requires the loopback path to use


### PR DESCRIPTION
## What

Gives self-hosters a **dependency-free** path to publish to Bluesky. Today, off the loopback origin, Share to Bluesky routes sign-in + writes through the `my.pantryhost.app` publish broker (shipped, works). This adds the *sovereign* alternative: host your own `client-metadata.json` and OAuth completes directly against your own instance — no pantryhost.app in the loop.

Both paths still write to the user's own repo on their own PDS. The broker stays the zero-config default; sovereignty is opt-in via `ATPROTO_CLIENT_ID`.

## Why

`#37` asked for two things: (1) a runtime channel so `ATPROTO_CLIENT_ID` reaches the Rex client (`process.env` isn't inlined into its bundle), and (2) a way for a self-hoster to serve their own client document with their origin in `redirect_uris`. The broker (merged earlier) fixed #37's *core* complaint — publishing off loopback now works — but a self-hoster who wants no third-party dependency needs this.

## Changes

- **`shared/atproto-client.ts`** (new, React-free): single source of truth for `ATPROTO_PUBLISH_OAUTH_SCOPE`, `OAUTH_CALLBACK_PATH`, `DEFAULT_CLIENT_METADATA_URL`, and `buildClientMetadata(baseUrl)`. `BlueskyAuth` re-exports the scope for back-compat.
- **`getProdClientId()`** reads an `atproto-client-id` meta tag (Rex browser channel, mirroring `atproto-publish-dry-run` / `api-origin`) → Vite env → `process.env` → hosted default.
- **`_document.tsx`** emits `<meta name="atproto-client-id">` from `process.env.ATPROTO_CLIENT_ID`.
- **`shouldUseBroker()`** returns `false` when a self-hosted client is configured (new `hasSelfHostedOAuthClient()`), so a sovereign instance does direct OAuth instead of the broker popup.
- **`gen-client-metadata.ts`**: CLI to generate the document for a public HTTPS origin (validates https; writes `redirect_uris` + `scope` from shared).
- **Docs**: `docs/self-hosted-oauth.md`, `.env.example` section, `CLAUDE.md` env entries.

## Verification

- App typecheck: **zero new errors** (119 = 119 baseline; remaining are pre-existing Rex `next/*` type-resolution noise + an unrelated `UrlRecipeDetail` mismatch).
- Web Vite build: clean (new shared import resolves through Vite's `import.meta.env` path).
- Stubbed-DOM logic check:
  - self-hosted Tailscale origin, no override → `shouldUseBroker: true`
  - same origin + `atproto-client-id` meta → `shouldUseBroker: false`
  - loopback → `false` regardless

Full end-to-end (a real second HTTPS domain hosting the document + a live OAuth round-trip) is a manual step for the self-hoster — see `docs/self-hosted-oauth.md`.

Refs #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)